### PR TITLE
Fix API to use real AJA KUMO REST endpoints, save to Documents with r…

### DIFF
--- a/src/agents/api_agent/__init__.py
+++ b/src/agents/api_agent/__init__.py
@@ -105,15 +105,11 @@ class APIAgent:
         protocol_used = Protocol.DEFAULT
 
         try:
-            # Method 1: Try REST bulk endpoints
-            logger.debug("Attempting REST bulk download")
+            # Method 1: Try REST API (uses real AJA /config?action=get&paramid= endpoints)
+            logger.debug("Attempting REST download via AJA KUMO API")
             async with RestClient(self.router_ip) as rest:
-                protocol_used, labels_dict = await rest.download_labels_bulk()
-
-                # Method 2: Try REST individual endpoints if bulk failed
-                if labels_dict is None:
-                    logger.debug("Bulk download failed, trying individual endpoints")
-                    protocol_used, labels_dict = await rest.download_labels_individual()
+                await rest.detect_port_count()
+                protocol_used, labels_dict = await rest.download_labels()
 
             # Method 3: Try Telnet if REST failed
             if labels_dict is None:

--- a/src/agents/api_agent/rest_client.py
+++ b/src/agents/api_agent/rest_client.py
@@ -1,13 +1,13 @@
 """Async REST API client for AJA KUMO routers.
 
-This module provides an async HTTP client for communicating with KUMO routers
-via their REST API endpoints.
+Uses the real AJA KUMO REST API:
+  GET /config?action=get&configid=0&paramid=eParamID_XPT_Source{N}_Line_1
+  GET /config?action=set&configid=0&paramid=eParamID_XPT_Source{N}_Line_1&value=NewName
 """
 
 import asyncio
 import logging
 from typing import Dict, List, Optional, Any, Tuple
-from datetime import datetime
 
 import aiohttp
 
@@ -16,10 +16,8 @@ from .router_protocols import (
     ResponseParser,
     DefaultLabelGenerator,
     Protocol,
-    TIMEOUT_BULK_REQUEST,
-    TIMEOUT_INDIVIDUAL_REQUEST,
-    DELAY_REST_REQUEST,
-    DELAY_UPLOAD_REQUEST,
+    KumoParamID,
+    TIMEOUT_REST_REQUEST,
     MAX_RETRIES,
     RETRY_BACKOFF_BASE,
     RETRY_BACKOFF_MULTIPLIER,
@@ -30,345 +28,168 @@ logger = logging.getLogger(__name__)
 
 
 class RestClientError(Exception):
-    """Base exception for REST client errors."""
-
     pass
 
 
 class ConnectionError(RestClientError):
-    """Exception raised when connection to router fails."""
-
     pass
 
 
 class TimeoutError(RestClientError):
-    """Exception raised when request times out."""
-
     pass
 
 
 class RestClient:
-    """Async REST API client for KUMO routers.
-
-    Provides methods for downloading and uploading port labels via REST API.
-    Implements retry logic with exponential backoff and multiple endpoint fallbacks.
-    """
+    """Async REST API client for KUMO routers using the real AJA API."""
 
     def __init__(self, router_ip: str):
-        """Initialize REST client.
-
-        Args:
-            router_ip: IP address of the KUMO router
-        """
         self.router_ip = router_ip
         self.base_url = f"http://{router_ip}"
         self._session: Optional[aiohttp.ClientSession] = None
+        self._port_count: int = 32
 
     async def __aenter__(self):
-        """Async context manager entry."""
         await self.connect()
         return self
 
     async def __aexit__(self, exc_type, exc_val, exc_tb):
-        """Async context manager exit."""
         await self.disconnect()
 
     async def connect(self) -> None:
-        """Create HTTP session."""
         if self._session is None:
-            timeout = aiohttp.ClientTimeout(total=TIMEOUT_BULK_REQUEST)
+            timeout = aiohttp.ClientTimeout(total=TIMEOUT_REST_REQUEST)
             self._session = aiohttp.ClientSession(timeout=timeout)
-            logger.info(f"REST client connected to {self.router_ip}")
 
     async def disconnect(self) -> None:
-        """Close HTTP session."""
         if self._session is not None:
             await self._session.close()
             self._session = None
-            logger.info(f"REST client disconnected from {self.router_ip}")
 
-    async def _make_request(
-        self,
-        method: str,
-        endpoint: str,
-        timeout: float = TIMEOUT_BULK_REQUEST,
-        json_data: Optional[Dict] = None,
-        retries: int = MAX_RETRIES,
-    ) -> Tuple[bool, Optional[Any]]:
-        """Make HTTP request with retry logic.
-
-        Args:
-            method: HTTP method (GET, PUT, POST)
-            endpoint: API endpoint path
-            timeout: Request timeout in seconds
-            json_data: Optional JSON data for POST/PUT requests
-            retries: Number of retry attempts
-
-        Returns:
-            Tuple of (success, response_data)
-        """
+    async def _get(self, endpoint: str, timeout: float = TIMEOUT_REST_REQUEST) -> Optional[Dict]:
+        """Make a GET request and return parsed JSON."""
         if self._session is None:
             await self.connect()
 
         url = f"{self.base_url}{endpoint}"
-        last_error = None
 
-        for attempt in range(retries):
+        for attempt in range(MAX_RETRIES):
             try:
-                # Calculate timeout for this attempt
-                request_timeout = aiohttp.ClientTimeout(total=timeout)
-
-                async with self._session.request(
-                    method,
-                    url,
-                    json=json_data,
-                    timeout=request_timeout,
-                ) as response:
+                req_timeout = aiohttp.ClientTimeout(total=timeout)
+                async with self._session.get(url, timeout=req_timeout) as response:
                     if response.status == 200:
-                        # Try to parse as JSON
                         try:
-                            data = await response.json()
-                            logger.debug(f"Request succeeded: {method} {endpoint}")
-                            return True, data
+                            return await response.json()
                         except Exception:
-                            # Return text if not JSON
                             text = await response.text()
-                            logger.debug(f"Request succeeded (text): {method} {endpoint}")
-                            return True, text
+                            return {"value": text.strip()} if text.strip() else None
                     else:
-                        logger.warning(
-                            f"Request failed with status {response.status}: {method} {endpoint}"
-                        )
-                        last_error = f"HTTP {response.status}"
-
+                        logger.warning(f"HTTP {response.status}: {endpoint}")
             except asyncio.TimeoutError:
-                last_error = f"Timeout after {timeout}s"
-                logger.warning(f"Request timeout (attempt {attempt + 1}/{retries}): {endpoint}")
-
+                logger.warning(f"Timeout (attempt {attempt + 1}): {endpoint}")
             except aiohttp.ClientError as e:
-                last_error = str(e)
-                logger.warning(f"Request error (attempt {attempt + 1}/{retries}): {endpoint} - {e}")
-
+                logger.warning(f"Client error (attempt {attempt + 1}): {e}")
             except Exception as e:
-                last_error = str(e)
-                logger.error(f"Unexpected error (attempt {attempt + 1}/{retries}): {endpoint} - {e}")
+                logger.error(f"Unexpected error: {e}")
 
-            # Exponential backoff before retry
-            if attempt < retries - 1:
-                backoff = RETRY_BACKOFF_BASE * (RETRY_BACKOFF_MULTIPLIER ** attempt)
-                await asyncio.sleep(backoff)
+            if attempt < MAX_RETRIES - 1:
+                await asyncio.sleep(RETRY_BACKOFF_BASE * (RETRY_BACKOFF_MULTIPLIER ** attempt))
 
-        logger.error(f"Request failed after {retries} attempts: {method} {endpoint} - {last_error}")
-        return False, None
+        return None
 
     async def test_connection(self) -> bool:
-        """Test connection to router.
-
-        Returns:
-            True if router is reachable, False otherwise
-        """
-        logger.info(f"Testing connection to {self.router_ip}")
-
-        # Try each bulk endpoint to find one that works
-        for endpoint in APIEndpoint.get_bulk_endpoints():
-            success, _ = await self._make_request("GET", endpoint, timeout=5, retries=1)
-            if success:
-                logger.info(f"Connection test successful via {endpoint}")
-                return True
-
-        logger.warning(f"Connection test failed to {self.router_ip}")
+        """Test connection by reading the system name."""
+        endpoint = APIEndpoint.get_system_name()
+        result = await self._get(endpoint, timeout=5)
+        if result and ResponseParser.parse_param_response(result):
+            return True
         return False
 
-    async def download_labels_bulk(self) -> Tuple[Protocol, Optional[Dict[str, List[str]]]]:
-        """Download all labels using bulk endpoints.
+    async def get_system_name(self) -> str:
+        """Get the router's system name."""
+        endpoint = APIEndpoint.get_system_name()
+        result = await self._get(endpoint)
+        if result:
+            name = ResponseParser.parse_param_response(result)
+            if name:
+                return name
+        return "KUMO"
+
+    async def detect_port_count(self) -> int:
+        """Detect router size (16, 32, or 64 ports)."""
+        # Check for 64-port
+        endpoint = APIEndpoint.get_source_name(33)
+        result = await self._get(endpoint, timeout=3)
+        if result and ResponseParser.parse_param_response(result):
+            self._port_count = 64
+            return 64
+
+        # Check for 32-port (try source 17)
+        endpoint = APIEndpoint.get_source_name(17)
+        result = await self._get(endpoint, timeout=3)
+        if result and ResponseParser.parse_param_response(result):
+            self._port_count = 32
+            return 32
+
+        self._port_count = 16
+        return 16
+
+    async def download_labels(self) -> Tuple[Protocol, Optional[Dict[str, List[str]]]]:
+        """Download all labels using the real AJA KUMO REST API.
 
         Returns:
-            Tuple of (protocol_used, labels_dict) where labels_dict contains
-            'inputs' and 'outputs' lists, or (Protocol.REST_BULK, None) if failed
+            Tuple of (protocol_used, labels_dict) where labels_dict has
+            'inputs' and 'outputs' lists of label strings
         """
-        logger.info(f"Attempting bulk label download from {self.router_ip}")
-
-        for endpoint in APIEndpoint.get_bulk_endpoints():
-            logger.debug(f"Trying bulk endpoint: {endpoint}")
-
-            success, response = await self._make_request(
-                "GET", endpoint, timeout=TIMEOUT_BULK_REQUEST, retries=2
-            )
-
-            if success and response:
-                # Try to parse response
-                if isinstance(response, dict):
-                    labels = ResponseParser.parse_bulk_config(response)
-                    if labels:
-                        logger.info(
-                            f"Bulk download successful via {endpoint} - "
-                            f"{len(labels['inputs'])} inputs, {len(labels['outputs'])} outputs"
-                        )
-                        return Protocol.REST_BULK, labels
-
-        logger.warning("Bulk label download failed - no valid responses")
-        return Protocol.REST_BULK, None
-
-    async def download_labels_individual(self) -> Tuple[Protocol, Optional[Dict[str, List[str]]]]:
-        """Download labels by querying each port individually.
-
-        Returns:
-            Tuple of (protocol_used, labels_dict) where labels_dict contains
-            'inputs' and 'outputs' lists, or (Protocol.REST_INDIVIDUAL, None) if failed
-        """
-        logger.info(f"Attempting individual port label download from {self.router_ip}")
-
+        port_count = self._port_count
         labels = {"inputs": [], "outputs": []}
-        success_count = 0
 
-        # Query all inputs
-        for port in range(1, 33):
-            label = await self._query_input_label(port)
-            if label:
-                labels["inputs"].append(label)
-                success_count += 1
-            else:
-                labels["inputs"].append(DefaultLabelGenerator.generate_input_label(port))
+        # Download source names (inputs)
+        for port in range(1, port_count + 1):
+            endpoint = APIEndpoint.get_source_name(port)
+            result = await self._get(endpoint)
+            label = None
+            if result:
+                label = ResponseParser.parse_param_response(result)
+            labels["inputs"].append(label or DefaultLabelGenerator.generate_input_label(port))
 
-            await asyncio.sleep(DELAY_REST_REQUEST)
+        # Download destination names (outputs)
+        for port in range(1, port_count + 1):
+            endpoint = APIEndpoint.get_dest_name(port)
+            result = await self._get(endpoint)
+            label = None
+            if result:
+                label = ResponseParser.parse_param_response(result)
+            labels["outputs"].append(label or DefaultLabelGenerator.generate_output_label(port))
 
-        # Query all outputs
-        for port in range(1, 33):
-            label = await self._query_output_label(port)
-            if label:
-                labels["outputs"].append(label)
-                success_count += 1
-            else:
-                labels["outputs"].append(DefaultLabelGenerator.generate_output_label(port))
-
-            await asyncio.sleep(DELAY_REST_REQUEST)
-
-        if success_count > 0:
-            logger.info(
-                f"Individual download successful - {success_count}/64 ports retrieved"
-            )
-            return Protocol.REST_INDIVIDUAL, labels
+        if any(l != DefaultLabelGenerator.generate_input_label(i + 1) for i, l in enumerate(labels["inputs"])):
+            return Protocol.REST, labels
         else:
-            logger.warning("Individual label download failed - no valid responses")
-            return Protocol.REST_INDIVIDUAL, None
-
-    async def _query_input_label(self, port: int) -> Optional[str]:
-        """Query label for a specific input port.
-
-        Args:
-            port: Port number (1-32)
-
-        Returns:
-            Label text, or None if query failed
-        """
-        for endpoint in APIEndpoint.get_individual_input_endpoints(port):
-            success, response = await self._make_request(
-                "GET", endpoint, timeout=TIMEOUT_INDIVIDUAL_REQUEST, retries=1
-            )
-
-            if success and response:
-                label = ResponseParser.parse_individual_port(response)
-                if label:
-                    logger.debug(f"Input {port} label: {label}")
-                    return label
-
-        logger.debug(f"Failed to query input {port} label")
-        return None
-
-    async def _query_output_label(self, port: int) -> Optional[str]:
-        """Query label for a specific output port.
-
-        Args:
-            port: Port number (1-32)
-
-        Returns:
-            Label text, or None if query failed
-        """
-        for endpoint in APIEndpoint.get_individual_output_endpoints(port):
-            success, response = await self._make_request(
-                "GET", endpoint, timeout=TIMEOUT_INDIVIDUAL_REQUEST, retries=1
-            )
-
-            if success and response:
-                label = ResponseParser.parse_individual_port(response)
-                if label:
-                    logger.debug(f"Output {port} label: {label}")
-                    return label
-
-        logger.debug(f"Failed to query output {port} label")
-        return None
+            logger.warning("REST download returned only default labels")
+            return Protocol.REST, None
 
     async def upload_label(
         self, port: int, port_type: str, label: str
     ) -> Tuple[bool, Optional[str]]:
-        """Upload a single label to the router.
-
-        Args:
-            port: Port number (1-32)
-            port_type: "INPUT" or "OUTPUT"
-            label: Label text to set
-
-        Returns:
-            Tuple of (success, error_message)
-        """
-        # Determine endpoint based on port type
+        """Upload a single label using the real AJA KUMO REST API."""
         if port_type.upper() == "INPUT":
-            endpoint = APIEndpoint.INPUT_LABEL_UPDATE.format(port=port)
+            endpoint = APIEndpoint.set_source_name(port, label)
         elif port_type.upper() == "OUTPUT":
-            endpoint = APIEndpoint.OUTPUT_LABEL_UPDATE.format(port=port)
+            endpoint = APIEndpoint.set_dest_name(port, label)
         else:
             return False, f"Invalid port type: {port_type}"
 
-        # Prepare request body
-        body = {"label": label}
-
-        # Try PUT request
-        success, response = await self._make_request(
-            "PUT", endpoint, timeout=TIMEOUT_INDIVIDUAL_REQUEST, json_data=body, retries=2
-        )
-
-        if success:
-            logger.debug(f"Uploaded {port_type} {port} label: {label}")
+        result = await self._get(endpoint)
+        if result is not None:
             return True, None
-
-        # Try alternative CGI endpoint with POST
-        cgi_endpoint = APIEndpoint.CGI_SET_LABEL
-        cgi_body = {
-            "type": port_type.lower(),
-            "port": port,
-            "label": label,
-        }
-
-        success, response = await self._make_request(
-            "POST", cgi_endpoint, timeout=TIMEOUT_INDIVIDUAL_REQUEST, json_data=cgi_body, retries=2
-        )
-
-        if success:
-            logger.debug(f"Uploaded {port_type} {port} label via CGI: {label}")
-            return True, None
-
-        error_msg = f"Failed to upload {port_type} {port} label"
-        logger.warning(error_msg)
-        return False, error_msg
+        return False, f"Failed to set {port_type} {port} label"
 
     async def upload_labels_batch(
         self, labels: List[Dict[str, Any]], progress_callback=None
     ) -> Tuple[int, int, List[str]]:
-        """Upload multiple labels to the router.
-
-        Args:
-            labels: List of label dictionaries with 'port', 'type', 'label' keys
-            progress_callback: Optional async callback(current, total, port_type, port)
-
-        Returns:
-            Tuple of (success_count, error_count, error_messages)
-        """
-        logger.info(f"Uploading {len(labels)} labels to {self.router_ip}")
-
+        """Upload multiple labels."""
         success_count = 0
         error_count = 0
         error_messages = []
-
         total = len(labels)
 
         for idx, label_data in enumerate(labels):
@@ -376,13 +197,10 @@ class RestClient:
             port_type = label_data["type"]
             label = label_data["label"]
 
-            # Update progress
             if progress_callback:
                 await progress_callback(idx + 1, total, port_type, port)
 
-            # Upload label
             success, error_msg = await self.upload_label(port, port_type, label)
-
             if success:
                 success_count += 1
             else:
@@ -390,10 +208,4 @@ class RestClient:
                 if error_msg:
                     error_messages.append(error_msg)
 
-            # Delay between requests
-            await asyncio.sleep(DELAY_UPLOAD_REQUEST)
-
-        logger.info(
-            f"Upload complete - {success_count} succeeded, {error_count} failed"
-        )
         return success_count, error_count, error_messages

--- a/src/agents/api_agent/router_protocols.py
+++ b/src/agents/api_agent/router_protocols.py
@@ -2,298 +2,235 @@
 
 This module defines the communication protocols, API endpoints, and response
 parsers for different KUMO router API formats.
+
+The AJA KUMO REST API uses:
+  GET  /config?action=get&configid=0&paramid={paramid}
+  GET  /config?action=set&configid=0&paramid={paramid}&value={value}
+  GET  /config?action=connect&configid=0              (get connection ID)
+  POST /authenticator/login                           (if auth enabled)
+
+Key eParamID values for labels:
+  eParamID_XPT_Source{N}_Line_1      - Source (input) name, line 1
+  eParamID_XPT_Source{N}_Line_2      - Source (input) name, line 2
+  eParamID_XPT_Destination{N}_Line_1 - Destination (output) name, line 1
+  eParamID_XPT_Destination{N}_Line_2 - Destination (output) name, line 2
+  eParamID_XPT_Destination{N}_Status - Crosspoint: which source routed to dest N
+  eParamID_SysName                   - Router system name
+  eParamID_SWVersion                 - Firmware version
 """
 
 from enum import Enum
 from typing import Dict, List, Optional, Any
 import re
+import urllib.parse
 
 
 class Protocol(Enum):
     """Communication protocols supported by KUMO routers."""
 
-    REST_BULK = "rest_bulk"
-    REST_INDIVIDUAL = "rest_individual"
+    REST = "rest"
     TELNET = "telnet"
     DEFAULT = "default"
 
 
+class KumoParamID:
+    """AJA KUMO eParamID constants."""
+
+    SYS_NAME = "eParamID_SysName"
+    SW_VERSION = "eParamID_SWVersion"
+
+    @staticmethod
+    def source_name(port: int, line: int = 1) -> str:
+        """Get eParamID for source (input) name.
+
+        Args:
+            port: Port number (1-64)
+            line: Name line (1 or 2, KUMO supports 2-line names)
+        """
+        return f"eParamID_XPT_Source{port}_Line_{line}"
+
+    @staticmethod
+    def dest_name(port: int, line: int = 1) -> str:
+        """Get eParamID for destination (output) name.
+
+        Args:
+            port: Port number (1-64)
+            line: Name line (1 or 2)
+        """
+        return f"eParamID_XPT_Destination{port}_Line_{line}"
+
+    @staticmethod
+    def dest_status(port: int) -> str:
+        """Get eParamID for crosspoint status (which source is routed to dest).
+
+        Args:
+            port: Destination port number (1-64)
+        """
+        return f"eParamID_XPT_Destination{port}_Status"
+
+
 class APIEndpoint:
-    """REST API endpoint definitions for KUMO routers."""
+    """REST API endpoint builder for AJA KUMO routers.
 
-    # Bulk configuration endpoints
-    BULK_CONFIG = "/api/config"
-    BULK_STATUS = "/api/status"
-    CGI_CONFIG = "/cgi-bin/config"
-    CONFIG_JSON = "/config.json"
-    STATUS_JSON = "/status.json"
+    All KUMO REST calls go through /config with query parameters.
+    """
 
-    # Individual port endpoints
-    INPUT_PORT = "/api/inputs/{port}"
-    OUTPUT_PORT = "/api/outputs/{port}"
-    CGI_GET_LABEL = "/cgi-bin/getlabel?type={port_type}&port={port}"
-
-    # Update endpoints
-    INPUT_LABEL_UPDATE = "/api/inputs/{port}/label"
-    OUTPUT_LABEL_UPDATE = "/api/outputs/{port}/label"
-    CGI_SET_LABEL = "/cgi-bin/setlabel"
-
-    @classmethod
-    def get_bulk_endpoints(cls) -> List[str]:
-        """Get list of bulk configuration endpoints to try.
-
-        Returns:
-            List of endpoint URLs in priority order
-        """
-        return [
-            cls.BULK_CONFIG,
-            cls.BULK_STATUS,
-            cls.CGI_CONFIG,
-            cls.CONFIG_JSON,
-            cls.STATUS_JSON,
-        ]
-
-    @classmethod
-    def get_individual_input_endpoints(cls, port: int) -> List[str]:
-        """Get list of individual input port endpoints to try.
+    @staticmethod
+    def get_param(param_id: str) -> str:
+        """Build GET endpoint for reading a parameter.
 
         Args:
-            port: Port number (1-32)
+            param_id: eParamID string
 
         Returns:
-            List of endpoint URLs with port number substituted
+            URL path with query string
         """
-        return [
-            cls.INPUT_PORT.format(port=port),
-            cls.CGI_GET_LABEL.format(port_type="input", port=port),
-        ]
+        return f"/config?action=get&configid=0&paramid={param_id}"
 
-    @classmethod
-    def get_individual_output_endpoints(cls, port: int) -> List[str]:
-        """Get list of individual output port endpoints to try.
+    @staticmethod
+    def set_param(param_id: str, value: str) -> str:
+        """Build SET endpoint for writing a parameter.
 
         Args:
-            port: Port number (1-32)
+            param_id: eParamID string
+            value: Value to set (will be URL-encoded)
 
         Returns:
-            List of endpoint URLs with port number substituted
+            URL path with query string
         """
-        return [
-            cls.OUTPUT_PORT.format(port=port),
-            cls.CGI_GET_LABEL.format(port_type="output", port=port),
-        ]
+        encoded = urllib.parse.quote(value, safe="")
+        return f"/config?action=set&configid=0&paramid={param_id}&value={encoded}"
+
+    @staticmethod
+    def connect() -> str:
+        """Build connection endpoint (gets a connection/session ID)."""
+        return "/config?action=connect&configid=0"
+
+    @staticmethod
+    def get_source_name(port: int, line: int = 1) -> str:
+        """Build endpoint to get source (input) name."""
+        return APIEndpoint.get_param(KumoParamID.source_name(port, line))
+
+    @staticmethod
+    def set_source_name(port: int, value: str, line: int = 1) -> str:
+        """Build endpoint to set source (input) name."""
+        return APIEndpoint.set_param(KumoParamID.source_name(port, line), value)
+
+    @staticmethod
+    def get_dest_name(port: int, line: int = 1) -> str:
+        """Build endpoint to get destination (output) name."""
+        return APIEndpoint.get_param(KumoParamID.dest_name(port, line))
+
+    @staticmethod
+    def set_dest_name(port: int, value: str, line: int = 1) -> str:
+        """Build endpoint to set destination (output) name."""
+        return APIEndpoint.set_param(KumoParamID.dest_name(port, line), value)
+
+    @staticmethod
+    def get_system_name() -> str:
+        """Build endpoint to get router system name."""
+        return APIEndpoint.get_param(KumoParamID.SYS_NAME)
+
+    @staticmethod
+    def get_firmware_version() -> str:
+        """Build endpoint to get firmware version."""
+        return APIEndpoint.get_param(KumoParamID.SW_VERSION)
 
 
 class TelnetCommand:
     """Telnet command definitions for KUMO routers."""
 
-    # Query commands
     QUERY_INPUT_LABEL = "LABEL INPUT {port} ?"
     QUERY_OUTPUT_LABEL = "LABEL OUTPUT {port} ?"
-
-    # Set commands
     SET_INPUT_LABEL = 'LABEL INPUT {port} "{label}"'
     SET_OUTPUT_LABEL = 'LABEL OUTPUT {port} "{label}"'
-
-    # Response pattern for label queries (captures quoted label)
     LABEL_RESPONSE_PATTERN = re.compile(r'"([^"]+)"')
 
     @classmethod
     def query_input(cls, port: int) -> str:
-        """Get query command for input port label.
-
-        Args:
-            port: Port number (1-32)
-
-        Returns:
-            Telnet command string
-        """
         return cls.QUERY_INPUT_LABEL.format(port=port)
 
     @classmethod
     def query_output(cls, port: int) -> str:
-        """Get query command for output port label.
-
-        Args:
-            port: Port number (1-32)
-
-        Returns:
-            Telnet command string
-        """
         return cls.QUERY_OUTPUT_LABEL.format(port=port)
 
     @classmethod
     def set_input(cls, port: int, label: str) -> str:
-        """Get set command for input port label.
-
-        Args:
-            port: Port number (1-32)
-            label: Label text to set
-
-        Returns:
-            Telnet command string
-        """
-        # Escape quotes in label
         escaped_label = label.replace('"', '\\"')
         return cls.SET_INPUT_LABEL.format(port=port, label=escaped_label)
 
     @classmethod
     def set_output(cls, port: int, label: str) -> str:
-        """Get set command for output port label.
-
-        Args:
-            port: Port number (1-32)
-            label: Label text to set
-
-        Returns:
-            Telnet command string
-        """
-        # Escape quotes in label
         escaped_label = label.replace('"', '\\"')
         return cls.SET_OUTPUT_LABEL.format(port=port, label=escaped_label)
 
     @classmethod
     def parse_label_response(cls, response: str) -> Optional[str]:
-        """Parse label from telnet response.
-
-        Args:
-            response: Raw telnet response string
-
-        Returns:
-            Extracted label text, or None if parsing failed
-        """
         if not response:
             return None
-
         match = cls.LABEL_RESPONSE_PATTERN.search(response)
-        if match:
-            return match.group(1)
-
-        return None
+        return match.group(1) if match else None
 
 
 class ResponseParser:
-    """Parsers for different KUMO router API response formats."""
+    """Parse JSON responses from KUMO REST API."""
 
     @staticmethod
-    def parse_bulk_config(response: Dict[str, Any]) -> Optional[Dict[str, List[str]]]:
-        """Parse bulk configuration response.
+    def parse_param_response(response: Dict[str, Any]) -> Optional[str]:
+        """Parse a /config?action=get response.
+
+        AJA KUMO returns JSON like:
+            {"paramid":"...", "name":"eParamID_...", "value":"...", "value_name":"..."}
 
         Args:
-            response: JSON response from bulk config endpoint
+            response: Parsed JSON dict from the API
 
         Returns:
-            Dictionary with 'inputs' and 'outputs' lists of labels, or None if invalid
+            The value string, or None
         """
-        try:
-            result = {"inputs": [], "outputs": []}
-
-            # Try direct format: {inputs: [...], outputs: [...]}
-            if "inputs" in response:
-                for i in range(32):
-                    if i < len(response["inputs"]):
-                        item = response["inputs"][i]
-                        label = item.get("label", f"Input {i + 1}") if isinstance(item, dict) else str(item)
-                        result["inputs"].append(label)
-                    else:
-                        result["inputs"].append(f"Input {i + 1}")
-
-            if "outputs" in response:
-                for i in range(32):
-                    if i < len(response["outputs"]):
-                        item = response["outputs"][i]
-                        label = item.get("label", f"Output {i + 1}") if isinstance(item, dict) else str(item)
-                        result["outputs"].append(label)
-                    else:
-                        result["outputs"].append(f"Output {i + 1}")
-
-            # Return only if we found at least some labels
-            if result["inputs"] or result["outputs"]:
-                return result
-
+        if not isinstance(response, dict):
             return None
 
-        except (KeyError, TypeError, IndexError):
-            return None
+        # value_name has the human-readable form
+        if response.get("value_name") and str(response["value_name"]).strip():
+            return str(response["value_name"]).strip()
 
-    @staticmethod
-    def parse_individual_port(response: Any) -> Optional[str]:
-        """Parse individual port query response.
+        # Fall back to value
+        if response.get("value") and str(response["value"]).strip():
+            return str(response["value"]).strip()
 
-        Args:
-            response: JSON response from individual port endpoint
-
-        Returns:
-            Label text, or None if parsing failed
-        """
-        try:
-            # Try dictionary format with 'label' key
-            if isinstance(response, dict) and "label" in response:
-                return str(response["label"])
-
-            # Try string format
-            if isinstance(response, str) and response.strip():
-                return response.strip()
-
-            return None
-
-        except (KeyError, TypeError):
-            return None
+        return None
 
 
 class DefaultLabelGenerator:
     """Generator for default labels when router communication fails."""
 
     @staticmethod
-    def generate_default_labels() -> Dict[str, List[str]]:
-        """Generate default labels for all ports.
-
-        Returns:
-            Dictionary with default 'inputs' and 'outputs' label lists
-        """
+    def generate_default_labels(port_count: int = 32) -> Dict[str, List[str]]:
         return {
-            "inputs": [f"Input {i + 1}" for i in range(32)],
-            "outputs": [f"Output {i + 1}" for i in range(32)],
+            "inputs": [f"Source {i + 1}" for i in range(port_count)],
+            "outputs": [f"Dest {i + 1}" for i in range(port_count)],
         }
 
     @staticmethod
     def generate_input_label(port: int) -> str:
-        """Generate default label for input port.
-
-        Args:
-            port: Port number (1-32)
-
-        Returns:
-            Default label string
-        """
-        return f"Input {port}"
+        return f"Source {port}"
 
     @staticmethod
     def generate_output_label(port: int) -> str:
-        """Generate default label for output port.
-
-        Args:
-            port: Port number (1-32)
-
-        Returns:
-            Default label string
-        """
-        return f"Output {port}"
+        return f"Dest {port}"
 
 
-# Timeout constants (in seconds)
-TIMEOUT_BULK_REQUEST = 10  # Bulk config requests
-TIMEOUT_INDIVIDUAL_REQUEST = 5  # Individual port requests
-TIMEOUT_TELNET_CONNECT = 5  # Telnet connection
-TIMEOUT_TELNET_COMMAND = 2  # Individual telnet command
+# Timeout constants (seconds)
+TIMEOUT_REST_REQUEST = 5
+TIMEOUT_TELNET_CONNECT = 5
+TIMEOUT_TELNET_COMMAND = 2
 
-# Delay constants (in seconds)
-DELAY_TELNET_INITIAL = 2  # Initial wait after telnet connection
-DELAY_TELNET_COMMAND = 0.2  # Delay between telnet commands
-DELAY_REST_REQUEST = 0.1  # Delay between individual REST requests
-DELAY_UPLOAD_REQUEST = 0.1  # Delay between upload requests
+# Delay constants (seconds)
+DELAY_TELNET_INITIAL = 1
+DELAY_TELNET_COMMAND = 0.15
 
 # Retry constants
-MAX_RETRIES = 3  # Maximum retry attempts for failed requests
-RETRY_BACKOFF_BASE = 1  # Base delay for exponential backoff (seconds)
-RETRY_BACKOFF_MULTIPLIER = 2  # Multiplier for exponential backoff
+MAX_RETRIES = 2
+RETRY_BACKOFF_BASE = 0.5
+RETRY_BACKOFF_MULTIPLIER = 2


### PR DESCRIPTION
…outer name

The app was using fake API endpoints (/api/inputs/1, /api/config, /cgi-bin/*) that don't exist on AJA KUMO routers. Replaced with the real AJA REST API:

  GET /config?action=get&configid=0&paramid=eParamID_XPT_Source{N}_Line_1
  GET /config?action=set&configid=0&paramid=eParamID_XPT_Source{N}_Line_1&value=NewName

Key changes:
- PowerShell GUI: connect tests with real API, downloads via eParamID params, auto-detects router name and port count (16/32/64), uploads via set action
- CLI updater: same correct API endpoints, auto-detects port count
- Python REST client: completely rewritten to use /config?action=get|set
- Router protocols: new KumoParamID class with source_name(), dest_name() helpers instead of fake bulk/individual endpoint lists
- Removed all unnecessary Sleep delays between API calls
- Files auto-save to Documents/KUMO_Labels/ with router name in filename
- Backups save to Documents/KUMO_Labels/ instead of temp folder

## Summary by Sourcery

Switch KUMO label management to the real AJA REST /config API and improve router metadata handling and defaults.

New Features:
- Add router name and port-count detection via AJA KUMO REST parameters in both the GUI and Excel updater tools.
- Automatically save downloaded labels and backups to a KUMO_Labels folder under the user Documents directory with router-specific filenames.

Bug Fixes:
- Fix REST label download and upload so they work against actual AJA KUMO routers instead of non-existent /api and /cgi-bin endpoints.

Enhancements:
- Replace legacy fake REST endpoints with proper /config?action=get|set paramid-based calls across the Python REST client, PowerShell GUI, and Excel updater.
- Unify REST protocol handling around a single REST mode with simplified timeout, retry, and response parsing logic using eParamID helpers.
- Adjust default label naming to use Source/Dest terminology and support variable router sizes (16/32/64 ports).
- Streamline Telnet fallback logic and reduce unnecessary sleep delays to make label downloads and uploads more responsive.