### PR TITLE
Fix 20+ bugs across PowerShell GUI, CLI, and Python backend

### DIFF
--- a/src/agents/api_agent/__init__.py
+++ b/src/agents/api_agent/__init__.py
@@ -137,7 +137,7 @@ class APIAgent:
             )
 
             # Emit event
-            self._emit_labels_event(
+            await self._emit_labels_event(
                 labels=labels,
                 source="router",
                 operation="download",
@@ -154,7 +154,7 @@ class APIAgent:
             labels_dict = DefaultLabelGenerator.generate_default_labels()
             labels = self._dict_to_labels(labels_dict)
 
-            self._emit_labels_event(
+            await self._emit_labels_event(
                 labels=labels,
                 source="default",
                 operation="download",

--- a/src/agents/api_agent/rest_client.py
+++ b/src/agents/api_agent/rest_client.py
@@ -31,11 +31,11 @@ class RestClientError(Exception):
     pass
 
 
-class ConnectionError(RestClientError):
+class RestConnectionError(RestClientError):
     pass
 
 
-class TimeoutError(RestClientError):
+class RestTimeoutError(RestClientError):
     pass
 
 
@@ -161,7 +161,16 @@ class RestClient:
                 label = ResponseParser.parse_param_response(result)
             labels["outputs"].append(label or DefaultLabelGenerator.generate_output_label(port))
 
-        if any(l != DefaultLabelGenerator.generate_input_label(i + 1) for i, l in enumerate(labels["inputs"])):
+        # Check if we got any real (non-default) labels for inputs OR outputs
+        has_real_inputs = any(
+            l != DefaultLabelGenerator.generate_input_label(i + 1)
+            for i, l in enumerate(labels["inputs"])
+        )
+        has_real_outputs = any(
+            l != DefaultLabelGenerator.generate_output_label(i + 1)
+            for i, l in enumerate(labels["outputs"])
+        )
+        if has_real_inputs or has_real_outputs:
             return Protocol.REST, labels
         else:
             logger.warning("REST download returned only default labels")

--- a/src/agents/base_agent.py
+++ b/src/agents/base_agent.py
@@ -92,7 +92,7 @@ class BaseAgent(ABC):
         self._event_queue = asyncio.Queue()
 
         # Subscribe to configured events
-        self._subscribe_to_events()
+        await self._subscribe_to_events()
 
         # Start event processing task
         self._event_task = asyncio.create_task(self._process_events())
@@ -123,7 +123,7 @@ class BaseAgent(ABC):
                 pass
 
         # Unsubscribe from events
-        self._unsubscribe_from_events()
+        await self._unsubscribe_from_events()
 
         # Clean up agent resources
         await self.cleanup()
@@ -150,31 +150,31 @@ class BaseAgent(ABC):
         # Mark with a special indicator
         self._subscribed_events.add(None)  # None indicates all events
 
-    def _subscribe_to_events(self) -> None:
+    async def _subscribe_to_events(self) -> None:
         """Subscribe agent to configured event types on the event bus."""
         if not self._event_queue:
             return
 
         if None in self._subscribed_events:
             # Subscribe to all events
-            self.event_bus.subscribe_all(self._event_queue)
+            await self.event_bus.subscribe_all(self._event_queue)
             logger.debug("Agent '%s' subscribed to all events on event bus", self.name)
         else:
             # Subscribe to specific event types
             for event_type in self._subscribed_events:
-                self.event_bus.subscribe(event_type, self._event_queue)
+                await self.event_bus.subscribe(event_type, self._event_queue)
                 logger.debug(
                     "Agent '%s' subscribed to %s on event bus",
                     self.name,
                     event_type.value
                 )
 
-    def _unsubscribe_from_events(self) -> None:
+    async def _unsubscribe_from_events(self) -> None:
         """Unsubscribe agent from all events on the event bus."""
         if not self._event_queue:
             return
 
-        self.event_bus.unsubscribe_all(self._event_queue)
+        await self.event_bus.unsubscribe_all(self._event_queue)
         logger.debug("Agent '%s' unsubscribed from all events", self.name)
 
     async def _process_events(self) -> None:

--- a/src/agents/file_handler/__init__.py
+++ b/src/agents/file_handler/__init__.py
@@ -4,7 +4,7 @@ File Handler Agent for managing CSV, Excel, and JSON files.
 Provides unified interface for loading and saving port data across multiple formats.
 """
 from pathlib import Path
-from typing import Optional, Literal
+from typing import Optional, Literal, Union
 from datetime import datetime
 
 from .schema import FileData, PortData
@@ -48,7 +48,7 @@ class FileHandlerAgent:
 
     def load(
         self,
-        file_path: str | Path,
+        file_path: Union[str, Path],
         file_format: Optional[FileFormat] = None,
     ) -> FileData:
         """
@@ -111,7 +111,7 @@ class FileHandlerAgent:
 
     def save(
         self,
-        file_path: str | Path,
+        file_path: Union[str, Path],
         data: FileData,
         file_format: Optional[FileFormat] = None,
         **kwargs,
@@ -175,7 +175,7 @@ class FileHandlerAgent:
 
     def create_template(
         self,
-        file_path: str | Path,
+        file_path: Union[str, Path],
         file_format: Optional[FileFormat] = None,
     ) -> None:
         """

--- a/src/agents/file_handler/json_handler.py
+++ b/src/agents/file_handler/json_handler.py
@@ -3,7 +3,7 @@ JSON file handler for nested structure.
 """
 from pathlib import Path
 import json
-from typing import Any, Dict
+from typing import Any, Dict, List
 
 from .schema import FileData, PortData
 
@@ -119,9 +119,9 @@ class JSONHandler:
 
     def _parse_port_list(
         self,
-        port_list: list[Dict[str, Any]],
+        port_list: List[Dict[str, Any]],
         default_type: str,
-    ) -> list[PortData]:
+    ) -> List[PortData]:
         """Parse a list of port dictionaries."""
         ports = []
         for idx, port_dict in enumerate(port_list):

--- a/src/cli.py
+++ b/src/cli.py
@@ -38,7 +38,7 @@ class KumoManager:
         self.settings = settings or Settings()
         self.event_bus = EventBus()
         self.api_agent = APIAgent(
-            router_ip=self.settings.kumo_host,
+            router_ip=self.settings.router_ip,
             event_bus=self.event_bus
         )
         self.file_handler = FileHandlerAgent(event_bus=self.event_bus)
@@ -53,7 +53,7 @@ class KumoManager:
             True if successful, False otherwise
         """
         try:
-            logger.info(f"Connecting to KUMO router at {self.settings.kumo_host}")
+            logger.info(f"Connecting to KUMO router at {self.settings.router_ip}")
 
             # Connect to router
             await self.api_agent.connect()
@@ -71,7 +71,7 @@ class KumoManager:
                     {
                         "port": label.port_number,
                         "type": label.port_type.value,
-                        "current_label": label.label_text,
+                        "current_label": label.current_label,
                         "new_label": "",
                         "notes": ""
                     }
@@ -81,7 +81,7 @@ class KumoManager:
                     {
                         "port": label.port_number,
                         "type": label.port_type.value,
-                        "current_label": label.label_text,
+                        "current_label": label.current_label,
                         "new_label": "",
                         "notes": ""
                     }
@@ -135,7 +135,7 @@ class KumoManager:
                 return True
 
             # Connect to router
-            logger.info(f"Connecting to KUMO router at {self.settings.kumo_host}")
+            logger.info(f"Connecting to KUMO router at {self.settings.router_ip}")
             await self.api_agent.connect()
 
             # Upload labels
@@ -181,7 +181,7 @@ def main():
     # Create settings
     settings = Settings()
     if args.ip:
-        settings.kumo_host = args.ip
+        settings.router_ip = args.ip
 
     # Create manager
     manager = KumoManager(settings)

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -66,14 +66,14 @@ class Settings(BaseSettings):
     min_port_number: int = Field(
         default=1,
         ge=1,
-        le=32,
+        le=64,
         description="Minimum valid port number"
     )
     max_port_number: int = Field(
-        default=32,
+        default=64,
         ge=1,
-        le=32,
-        description="Maximum valid port number"
+        le=64,
+        description="Maximum valid port number (supports 16, 32, or 64 port routers)"
     )
     max_label_length: int = Field(
         default=50,

--- a/src/coordinator/event_bus.py
+++ b/src/coordinator/event_bus.py
@@ -89,13 +89,13 @@ class EventBus:
                     len(self._subscribers[event_type])
                 )
 
-    def unsubscribe_all(self, queue: asyncio.Queue) -> None:
+    async def unsubscribe_all(self, queue: asyncio.Queue) -> None:
         """Unsubscribe from all event types.
 
         Args:
             queue: Queue to remove from all subscriptions
         """
-        with self._lock:
+        async with self._lock:
             # Remove from global subscribers
             if queue in self._global_subscribers:
                 self._global_subscribers.remove(queue)
@@ -129,7 +129,7 @@ class EventBus:
         )
 
         # Get subscribers for this event type
-        with self._lock:
+        async with self._lock:
             specific_subscribers = self._subscribers[event.event_type].copy()
             global_subscribers = self._global_subscribers.copy()
 
@@ -187,7 +187,7 @@ class EventBus:
                 exc_info=True
             )
 
-    def get_subscriber_count(self, event_type: EventType) -> int:
+    async def get_subscriber_count(self, event_type: EventType) -> int:
         """Get number of subscribers for a specific event type.
 
         Args:
@@ -196,21 +196,21 @@ class EventBus:
         Returns:
             Number of subscribers
         """
-        with self._lock:
+        async with self._lock:
             return len(self._subscribers[event_type])
 
-    def get_global_subscriber_count(self) -> int:
+    async def get_global_subscriber_count(self) -> int:
         """Get number of global subscribers.
 
         Returns:
             Number of global subscribers
         """
-        with self._lock:
+        async with self._lock:
             return len(self._global_subscribers)
 
-    def clear_all_subscribers(self) -> None:
+    async def clear_all_subscribers(self) -> None:
         """Clear all subscribers from the event bus."""
-        with self._lock:
+        async with self._lock:
             self._subscribers.clear()
             self._global_subscribers.clear()
             logger.info("All subscribers cleared from event bus")
@@ -223,7 +223,7 @@ class EventBus:
     async def stop(self) -> None:
         """Stop the event bus and clear all subscribers."""
         self._running = False
-        self.clear_all_subscribers()
+        await self.clear_all_subscribers()
         logger.info("EventBus stopped")
 
     def is_running(self) -> bool:


### PR DESCRIPTION
PowerShell GUI (KUMO-Label-Manager.ps1):
- Fix WinForms dock order causing scrambled panel layout
- Fix Find & Replace counting all labels instead of matched ones
- Fix Auto-Number applying in reverse order on selected rows
- Fix null reference crash in search filter
- Fix regex backreference bug in replace (use literal String.Replace)
- Remove dead code (Invoke-SecureRestMethod, Get-KumoRouterName)

PowerShell CLI (KUMO-Excel-Updater.ps1):
- Fix Telnet fallback being dead code (REST swallowed all errors)
- Fix Telnet hardcoded 32 ports (now uses detected port count)
- Fix resource leaks with finally blocks for TCP cleanup
- Remove dead code (Invoke-SecureRestMethod)

Python backend:
- Fix cli.py using non-existent settings.kumo_host (now router_ip)
- Fix cli.py using non-existent label.label_text (now current_label)
- Fix EventBus using sync 'with' on asyncio.Lock (now async with)
- Fix BaseAgent calling async subscribe methods without await
- Fix api_agent missing await on _emit_labels_event calls
- Fix rest_client only checking inputs for real labels (now checks both)
- Fix rest_client shadowing builtin ConnectionError/TimeoutError
- Fix schema rejecting valid INPUT+OUTPUT with same port number
- Fix Python 3.8 compat (str|Path -> Union, list[] -> List[])
- Fix settings port range 1-32 -> 1-64 for 64-port routers

## Summary by Sourcery

Fix multiple issues across the PowerShell tools and Python backend to improve label handling reliability, router compatibility, and event-driven coordination.

Bug Fixes:
- Allow Telnet label queries and default templates in the PowerShell CLI to respect the detected router port count instead of a hardcoded 32 ports.
- Ensure PowerShell CLI Telnet connections and streams are always cleaned up using finally blocks, and surface REST update failures so callers can fall back to Telnet.
- Correct WinForms dock ordering in the PowerShell GUI so panels render in the intended layout.
- Prevent null reference errors and incorrect matches in the PowerShell GUI search and find/replace logic, and ensure auto-numbering applies in a predictable row order.
- Update the Python CLI to use the correct router_ip setting and current_label field when reading labels.
- Fix the event bus to use async locks consistently and make subscription management methods asynchronous, with BaseAgent awaiting subscribe/unsubscribe calls.
- Ensure the API agent awaits label event emission and the REST client treats either input or output non-default labels as a successful REST download.
- Adjust schema validation to allow matching INPUT and OUTPUT ports with the same number and raise on true duplicate port/type pairs.
- Expand supported port counts and label file schema limits to handle up to 64-port routers (128 total ports in files).
- Restore Python 3.8 compatibility by replacing PEP 604 and builtin generic type annotations with typing.Union and typing.List.
- Avoid shadowing builtin ConnectionError and TimeoutError by renaming REST client exceptions.

Enhancements:
- Remove unused helper functions from the PowerShell GUI and CLI scripts.
- Clarify and centralize form control additions in the PowerShell GUI to make dock behavior explicit and maintainable.