### PR TITLE
security/perf: IPC hardening, CSP, and Kumo fetch optimization

### DIFF
--- a/electron/package-lock.json
+++ b/electron/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "helix-label-manager",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "helix-label-manager",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
         "@tanstack/react-table": "^8.20.0",

--- a/electron/src/main/index.ts
+++ b/electron/src/main/index.ts
@@ -40,7 +40,9 @@ function createWindow(): void {
   })
 
   mainWindow.webContents.setWindowOpenHandler((details) => {
-    shell.openExternal(details.url)
+    if (/^https?:/i.test(details.url)) {
+      shell.openExternal(details.url)
+    }
     return { action: 'deny' }
   })
 

--- a/electron/src/main/ipc-handlers.ts
+++ b/electron/src/main/ipc-handlers.ts
@@ -1,26 +1,66 @@
 // All ipcMain.handle() registrations
 
-import { ipcMain, BrowserWindow } from 'electron'
+import { ipcMain, BrowserWindow, app } from 'electron'
+import { isAbsolute, resolve as resolvePath, sep } from 'path'
 import * as routerAgent from './protocols/router-agent'
 import { detectRouterType } from './protocols/auto-detect'
 import { scanSubnet } from './protocols/network-scanner'
 import * as fileAgent from './file-io/file-agent'
 import { getSettings, setSettings, addRecentFile, getRecentFiles } from './settings-store'
 import { Label, PortData } from './protocols/types'
+import { validateIpAddress, validatePortNumber } from './utils/validation'
 
 function sendToRenderer(channel: string, ...args: unknown[]): void {
   const win = BrowserWindow.getAllWindows()[0]
   if (win) win.webContents.send(channel, ...args)
 }
 
+function isPrivateSubnetBase(base: string): boolean {
+  // Accept "a.b.c" (3-octet prefix) where base IP is in RFC1918 range
+  const parts = base.split('.')
+  if (parts.length !== 3) return false
+  const octets = parts.map(p => parseInt(p, 10))
+  if (octets.some(n => isNaN(n) || n < 0 || n > 255)) return false
+  if (parts.some((p, i) => String(octets[i]) !== p)) return false
+  const [a, b] = octets
+  if (a === 10) return true
+  if (a === 172 && b >= 16 && b <= 31) return true
+  if (a === 192 && b === 168) return true
+  if (a === 169 && b === 254) return true // link-local
+  return false
+}
+
+function isSafeUserPath(filePath: string): boolean {
+  if (typeof filePath !== 'string' || !filePath) return false
+  if (!isAbsolute(filePath)) return false
+  const resolved = resolvePath(filePath)
+  const allowedRoots = [
+    app.getPath('documents'),
+    app.getPath('desktop'),
+    app.getPath('downloads'),
+    app.getPath('userData'),
+    app.getPath('home'),
+    app.getPath('temp'),
+  ].map(p => resolvePath(p))
+  return allowedRoots.some(root => resolved === root || resolved.startsWith(root + sep))
+}
+
 export function registerIpcHandlers(): void {
   // --- Router ---
   ipcMain.handle('router:connect', async (_event, ip: string, routerType?: string) => {
+    if (!validateIpAddress(ip)) {
+      sendToRenderer('connection-status', 'error')
+      return { success: false, error: 'Invalid IP address', routerType: 'kumo', deviceName: '', inputCount: 0, outputCount: 0 }
+    }
+    const allowedTypes = ['kumo', 'videohub', 'lightware'] as const
+    const typedRouter = (routerType && allowedTypes.includes(routerType as typeof allowedTypes[number]))
+      ? (routerType as typeof allowedTypes[number])
+      : undefined
     try {
       sendToRenderer('connection-status', 'connecting')
       const result = await routerAgent.connect(
         ip,
-        routerType as 'kumo' | 'videohub' | 'lightware' | undefined,
+        typedRouter,
         (done, total) => sendToRenderer('progress', { done, total, phase: 'connect' })
       )
       sendToRenderer('connection-status', result.success ? 'connected' : 'disconnected')
@@ -38,10 +78,15 @@ export function registerIpcHandlers(): void {
   })
 
   ipcMain.handle('router:detect-type', async (_event, ip: string) => {
+    if (!validateIpAddress(ip)) return null
     return detectRouterType(ip)
   })
 
   ipcMain.handle('router:scan-subnet', async (_event, baseIp: string) => {
+    if (!isPrivateSubnetBase(baseIp)) {
+      sendToRenderer('error', 'Subnet scan refused: base must be an RFC1918 private prefix (e.g. 192.168.1)')
+      return []
+    }
     try {
       const results = await scanSubnet(baseIp, (progress) => {
         sendToRenderer('scan-progress', progress)
@@ -88,6 +133,7 @@ export function registerIpcHandlers(): void {
   })
 
   ipcMain.handle('router:set-route', async (_event, output: number, input: number) => {
+    if (!validatePortNumber(output) || !validatePortNumber(input)) return false
     try {
       return await routerAgent.setRoute(output, input)
     } catch (e) {
@@ -109,6 +155,10 @@ export function registerIpcHandlers(): void {
   })
 
   ipcMain.handle('file:save', async (_event, path: string, data: { ports: PortData[] }) => {
+    if (!isSafeUserPath(path)) {
+      sendToRenderer('error', 'Save refused: path is outside allowed user directories')
+      return
+    }
     try {
       await fileAgent.saveFile(path, data)
       addRecentFile(path)
@@ -146,6 +196,10 @@ export function registerIpcHandlers(): void {
   })
 
   ipcMain.handle('file:open-default-template', async (_event, name: string) => {
+    if (typeof name !== 'string' || !/^[A-Za-z0-9 _.\-]+$/.test(name)) {
+      sendToRenderer('error', 'Template name contains disallowed characters')
+      return null
+    }
     try {
       return await fileAgent.openDefaultTemplate(name)
     } catch (e) {

--- a/electron/src/main/protocols/kumo-rest.ts
+++ b/electron/src/main/protocols/kumo-rest.ts
@@ -110,24 +110,23 @@ async function parallelLimit<T>(
 }
 
 export async function kumoTestConnection(ip: string): Promise<boolean> {
+  return (await kumoProbeSystemName(ip)) !== null
+}
+
+// Returns the parsed system name if reachable, else null — single HTTP call.
+export async function kumoProbeSystemName(ip: string): Promise<string | null> {
   try {
     const resp = await fetchWithTimeout(getUrl(ip, 'eParamID_SysName'), CONNECT_TIMEOUT)
-    if (!resp.ok) return false
+    if (!resp.ok) return null
     const json = await resp.json()
-    return parseParamResponse(json) !== null
+    return parseParamResponse(json)
   } catch {
-    return false
+    return null
   }
 }
 
 export async function kumoGetSystemName(ip: string): Promise<string> {
-  try {
-    const resp = await fetchWithTimeout(getUrl(ip, 'eParamID_SysName'))
-    const json = await resp.json()
-    return parseParamResponse(json) || 'KUMO'
-  } catch {
-    return 'KUMO'
-  }
+  return (await kumoProbeSystemName(ip)) || 'KUMO'
 }
 
 export async function kumoGetFirmwareVersion(ip: string): Promise<string> {
@@ -154,18 +153,18 @@ export async function kumoDetectPortCount(ip: string): Promise<number> {
 }
 
 export async function kumoConnect(ip: string): Promise<ConnectResult> {
-  const isConnected = await kumoTestConnection(ip)
-  if (!isConnected) {
-    return { success: false, routerType: 'kumo', deviceName: '', inputCount: 0, outputCount: 0, error: `Cannot connect to KUMO at ${ip}` }
-  }
-  const [deviceName, portCount] = await Promise.all([
-    kumoGetSystemName(ip),
+  // Probe SysName + port count in parallel; SysName doubles as the connection test.
+  const [sysName, portCount] = await Promise.all([
+    kumoProbeSystemName(ip),
     kumoDetectPortCount(ip),
   ])
+  if (sysName === null) {
+    return { success: false, routerType: 'kumo', deviceName: '', inputCount: 0, outputCount: 0, error: `Cannot connect to KUMO at ${ip}` }
+  }
   return {
     success: true,
     routerType: 'kumo',
-    deviceName,
+    deviceName: sysName || 'KUMO',
     inputCount: portCount,
     outputCount: portCount,
   }
@@ -176,11 +175,13 @@ export async function kumoDownloadLabels(
   portCount: number,
   onProgress?: (done: number, total: number) => void
 ): Promise<Label[]> {
-  type FetchResult = { port: number; portType: 'INPUT' | 'OUTPUT'; line: number; label: string | null }
+  type LabelResult = { kind: 'label'; port: number; portType: 'INPUT' | 'OUTPUT'; line: number; label: string | null }
+  type ColorResult = { kind: 'color'; port: number; portType: 'INPUT' | 'OUTPUT'; color: number }
+  type FetchResult = LabelResult | ColorResult
 
   const tasks: (() => Promise<FetchResult>)[] = []
 
-  // Build all fetch tasks for inputs and outputs, lines 1 and 2
+  // Label fetches (lines 1+2) and color fetches all go into a single concurrency-limited batch.
   for (const portType of ['INPUT', 'OUTPUT'] as const) {
     for (let port = 1; port <= portCount; port++) {
       for (const line of [1, 2]) {
@@ -189,63 +190,50 @@ export async function kumoDownloadLabels(
           try {
             const resp = await fetchWithTimeout(getUrl(ip, paramId))
             const json = await resp.json()
-            return { port, portType, line, label: parseParamResponse(json) }
+            return { kind: 'label', port, portType, line, label: parseParamResponse(json) }
           } catch {
-            return { port, portType, line, label: null }
+            return { kind: 'label', port, portType, line, label: null }
           }
         })
       }
+      const colorParamId = buttonColorParam(port, portType)
+      tasks.push(async () => {
+        try {
+          const resp = await fetchWithTimeout(getUrl(ip, colorParamId))
+          const json = await resp.json()
+          const raw = json.value || json.value_name || null
+          const color = parseButtonColor(typeof raw === 'string' ? raw : null)
+          return { kind: 'color', port, portType, color }
+        } catch {
+          return { kind: 'color', port, portType, color: KUMO_DEFAULT_COLOR }
+        }
+      })
     }
   }
 
   const results = await parallelLimit(tasks, MAX_CONCURRENT, onProgress)
 
-  // Build label map
   const labelMap = new Map<string, { l1: string; l2: string }>()
+  const colorMap = new Map<string, number>()
   for (let port = 1; port <= portCount; port++) {
     labelMap.set(`INPUT-${port}`, { l1: `Source ${port}`, l2: '' })
     labelMap.set(`OUTPUT-${port}`, { l1: `Dest ${port}`, l2: '' })
   }
 
   for (const r of results) {
-    if (r && !(r instanceof Error)) {
-      const key = `${r.portType}-${r.port}`
+    if (!r || r instanceof Error) continue
+    const key = `${r.portType}-${r.port}`
+    if (r.kind === 'label') {
       const entry = labelMap.get(key)
       if (entry && r.label) {
         if (r.line === 1) entry.l1 = r.label
         else entry.l2 = r.label
       }
+    } else {
+      colorMap.set(key, r.color)
     }
   }
 
-  // Fetch colors in parallel
-  const colorTasks: (() => Promise<{ port: number; portType: 'INPUT' | 'OUTPUT'; color: number }>)[] = []
-  for (const portType of ['INPUT', 'OUTPUT'] as const) {
-    for (let port = 1; port <= portCount; port++) {
-      const paramId = buttonColorParam(port, portType)
-      colorTasks.push(async () => {
-        try {
-          const resp = await fetchWithTimeout(getUrl(ip, paramId))
-          const json = await resp.json()
-          const raw = json.value || json.value_name || null
-          const color = parseButtonColor(typeof raw === 'string' ? raw : null)
-          return { port, portType, color }
-        } catch {
-          return { port, portType, color: KUMO_DEFAULT_COLOR }
-        }
-      })
-    }
-  }
-
-  const colorResults = await parallelLimit(colorTasks, MAX_CONCURRENT)
-  const colorMap = new Map<string, number>()
-  for (const r of colorResults) {
-    if (r && !(r instanceof Error)) {
-      colorMap.set(`${r.portType}-${r.port}`, r.color)
-    }
-  }
-
-  // Assemble Label array
   const labels: Label[] = []
   for (const portType of ['INPUT', 'OUTPUT'] as const) {
     for (let port = 1; port <= portCount; port++) {

--- a/electron/src/preload/index.ts
+++ b/electron/src/preload/index.ts
@@ -1,51 +1,52 @@
-import { contextBridge, ipcRenderer } from 'electron'
+import { contextBridge, ipcRenderer, IpcRendererEvent } from 'electron'
+import type { Label, PortData, AppSettings, ConnectResult, UploadResult, Crosspoint, FileData, RouterType } from '../main/protocols/types'
 
 export type HelixAPI = typeof helixAPI
 
 const helixAPI = {
   // Router operations
   router: {
-    connect: (ip: string, routerType?: string) =>
+    connect: (ip: string, routerType?: RouterType): Promise<ConnectResult> =>
       ipcRenderer.invoke('router:connect', ip, routerType),
-    disconnect: () =>
+    disconnect: (): Promise<void> =>
       ipcRenderer.invoke('router:disconnect'),
-    detectType: (ip: string) =>
+    detectType: (ip: string): Promise<RouterType | null> =>
       ipcRenderer.invoke('router:detect-type', ip),
-    download: () =>
+    download: (): Promise<Label[]> =>
       ipcRenderer.invoke('router:download'),
-    upload: (labels: unknown[]) =>
+    upload: (labels: Label[]): Promise<UploadResult> =>
       ipcRenderer.invoke('router:upload', labels),
-    getCrosspoints: () =>
+    getCrosspoints: (): Promise<Crosspoint[]> =>
       ipcRenderer.invoke('router:get-crosspoints'),
-    setRoute: (output: number, input: number) =>
+    setRoute: (output: number, input: number): Promise<boolean> =>
       ipcRenderer.invoke('router:set-route', output, input),
-    scanSubnet: (baseIp: string) =>
+    scanSubnet: (baseIp: string): Promise<Array<{ ip: string; routerType: RouterType }>> =>
       ipcRenderer.invoke('router:scan-subnet', baseIp),
   },
 
   // File operations
   file: {
-    open: (filters?: unknown) =>
-      ipcRenderer.invoke('file:open', filters),
-    save: (path: string, data: unknown) =>
+    open: (): Promise<FileData | null> =>
+      ipcRenderer.invoke('file:open'),
+    save: (path: string, data: { ports: PortData[] }): Promise<void> =>
       ipcRenderer.invoke('file:save', path, data),
-    saveAs: (data: unknown) =>
+    saveAs: (data: { ports: PortData[] }): Promise<string | null> =>
       ipcRenderer.invoke('file:save-as', data),
-    createTemplate: (path: string, portCount: number) =>
+    createTemplate: (path: string, portCount: number): Promise<FileData | null> =>
       ipcRenderer.invoke('file:create-template', path, portCount),
-    getRecent: () =>
+    getRecent: (): Promise<string[]> =>
       ipcRenderer.invoke('file:get-recent'),
-    getDefaultTemplates: () =>
+    getDefaultTemplates: (): Promise<string[]> =>
       ipcRenderer.invoke('file:get-default-templates'),
-    openDefaultTemplate: (name: string) =>
+    openDefaultTemplate: (name: string): Promise<FileData | null> =>
       ipcRenderer.invoke('file:open-default-template', name),
   },
 
   // Settings
   settings: {
-    get: () =>
+    get: (): Promise<AppSettings> =>
       ipcRenderer.invoke('settings:get'),
-    set: (partial: unknown) =>
+    set: (partial: Partial<AppSettings>): Promise<void> =>
       ipcRenderer.invoke('settings:set', partial),
   },
 
@@ -76,16 +77,25 @@ const helixAPI = {
       'scan-progress',
     ]
     if (validChannels.includes(channel)) {
-      const subscription = (_event: unknown, ...args: unknown[]) => callback(...args)
+      const subscription = (_event: IpcRendererEvent, ...args: unknown[]) => callback(...args)
       ipcRenderer.on(channel, subscription)
       return () => { ipcRenderer.removeListener(channel, subscription) }
     }
     return () => {}
   },
 
-  // Remove all listeners for a channel
+  // Remove all listeners for a channel — restricted to the same allowlist as on()
   removeAllListeners: (channel: string) => {
-    ipcRenderer.removeAllListeners(channel)
+    const validChannels = [
+      'progress', 'connection-status', 'error', 'scan-progress',
+      'menu:new', 'menu:open', 'menu:save', 'menu:save-as', 'menu:create-template',
+      'menu:connect', 'menu:disconnect', 'menu:download', 'menu:upload',
+      'menu:crosspoint', 'menu:find-replace', 'menu:auto-number', 'menu:bulk-ops',
+      'menu:statistics', 'menu:settings', 'menu:undo', 'menu:redo', 'menu:about',
+    ]
+    if (validChannels.includes(channel)) {
+      ipcRenderer.removeAllListeners(channel)
+    }
   },
 }
 

--- a/electron/src/renderer/components/dialogs/Settings.tsx
+++ b/electron/src/renderer/components/dialogs/Settings.tsx
@@ -7,7 +7,7 @@ interface AppSettings {
   defaultFilePath: string
   autoConnect: boolean
   maxLabelLength: number
-  theme: string
+  theme: 'dark' | 'light'
 }
 
 export default function Settings() {

--- a/electron/src/renderer/components/layout/Sidebar.tsx
+++ b/electron/src/renderer/components/layout/Sidebar.tsx
@@ -51,7 +51,9 @@ export default function Sidebar() {
   }
 
   const handleQuickConnect = async (saved: { name: string; ip: string; routerType?: string }) => {
-    await connect(saved.ip, saved.routerType)
+    const allowed = ['kumo', 'videohub', 'lightware'] as const
+    const rt = allowed.find(t => t === saved.routerType)
+    await connect(saved.ip, rt)
   }
 
   return (

--- a/electron/src/renderer/components/router/ConnectDialog.tsx
+++ b/electron/src/renderer/components/router/ConnectDialog.tsx
@@ -29,7 +29,9 @@ export default function ConnectDialog() {
 
   const handleConnect = async () => {
     if (!ip.trim()) return
-    await connect(ip.trim(), routerType || undefined)
+    const allowed = ['kumo', 'videohub', 'lightware'] as const
+    const rt = allowed.find(t => t === routerType)
+    await connect(ip.trim(), rt)
     closeDialog()
   }
 

--- a/electron/src/renderer/hooks/useRouter.ts
+++ b/electron/src/renderer/hooks/useRouter.ts
@@ -1,13 +1,14 @@
 import { useRouterStore } from '../stores/router-store'
 import { useLabelsStore, LabelRow } from '../stores/labels-store'
 import { useUIStore } from '../stores/ui-store'
+import type { RouterType } from '../../main/protocols/types'
 
 export function useRouter() {
   const router = useRouterStore()
   const labelsStore = useLabelsStore()
   const ui = useUIStore()
 
-  const connect = async (ip: string, routerType?: string) => {
+  const connect = async (ip: string, routerType?: RouterType) => {
     router.setIp(ip)
     router.setConnecting()
     const result = await window.helix.router.connect(ip, routerType)

--- a/electron/src/renderer/index.html
+++ b/electron/src/renderer/index.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self' http: https: ws: wss:; font-src 'self' data:" />
   <title>Helix Label Manager</title>
 </head>
 <body class="bg-helix-bg text-helix-text overflow-hidden">


### PR DESCRIPTION
## Summary
Batch of quick-win audit fixes from a 12-agent parallel review of the repo. All changes are minor and isolated — no architectural shifts.

**Security**
- Validate IP on all `router:*` IPC handlers (connect, detect-type, scan-subnet, set-route)
- Restrict `router:scan-subnet` to RFC1918 / link-local prefixes only (prevents SSRF-to-internet from a compromised renderer)
- Path containment on `file:save` (resolves under Documents/Desktop/Downloads/userData/home/temp only)
- Allowlist template-name characters on `file:open-default-template` (blocks path traversal)
- Narrow `router:connect` `routerType` arg to the allowed union
- Add CSP meta tag to `renderer/index.html`
- Restrict `setWindowOpenHandler` to `http(s):` before `shell.openExternal`
- Apply `validChannels` allowlist to preload `removeAllListeners`

**Performance**
- `kumoConnect`: remove duplicate `SysName` fetch — `kumoProbeSystemName` now doubles as the connection test + name probe in a single HTTP round-trip
- `kumoDownloadLabels`: merge label + color fetches into one concurrency-limited batch instead of two sequential `parallelLimit` passes (eliminates the full label-fetch wait before color fetch starts)

**Types**
- Type preload IPC boundary with `Label[]`, `PortData`, `AppSettings`, `FileData` — removes downstream `unknown` casts
- Narrow `theme` to `'dark' | 'light'` in `Settings.tsx`
- Narrow `routerType` to `RouterType` in `useRouter`, `Sidebar`, `ConnectDialog`

## Deferred (out of scope for this PR)
- 64×64 crosspoint matrix virtualization — requires `react-window` dep + UI regression testing, deserves its own PR.

## Test plan
- [x] `npm run typecheck` passes clean
- [x] `npm run build` passes (main/preload/renderer bundles all emit)
- [ ] Manual smoke: connect to a KUMO on 192.168.100.x and verify label download still populates line 1, line 2, and color correctly
- [ ] Manual smoke: connect to a Videohub and Lightware — confirm routing unchanged
- [ ] Manual smoke: `File → Save As` to Documents succeeds; direct write to `C:\Windows\...` is refused with a toast
- [ ] Manual smoke: subnet scan on `192.168.1` works; `8.8.8` is refused
- [ ] Manual smoke: CSP meta doesn't break any renderer asset loading (inline scripts/styles still allowed for Tailwind/Vite)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Harden IPC and navigation security while optimizing KUMO router fetches and tightening IPC typings.

Bug Fixes:
- Validate router IPC inputs and restrict subnet scanning to private ranges to prevent unsafe network operations.
- Enforce path containment and safe template names for file IPC operations to avoid writing outside user directories or path traversal.
- Limit external URL opening and IPC event listener removal to safe, allow‑listed targets.

Enhancements:
- Reuse a single KUMO system-name probe for both connectivity checks and name retrieval to remove redundant HTTP requests.
- Batch KUMO label and color fetches into one concurrency-limited pass to reduce label download latency.
- Add a Content Security Policy to the renderer HTML to constrain webview resource loading.
- Tighten preload IPC API and renderer code to use concrete domain types for router operations, labels, settings, and files.