### PR TITLE
perf: virtualize crosspoint matrix with react-window

### DIFF
--- a/electron/package-lock.json
+++ b/electron/package-lock.json
@@ -1,20 +1,22 @@
 {
   "name": "helix-label-manager",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "helix-label-manager",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
         "@tanstack/react-table": "^8.20.0",
+        "@types/react-window": "^1.8.8",
         "electron-store": "^8.2.0",
         "exceljs": "^4.4.0",
         "papaparse": "^5.4.1",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
+        "react-window": "^1.8.11",
         "zustand": "^5.0.0"
       },
       "devDependencies": {
@@ -297,6 +299,15 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/template": {
@@ -2260,7 +2271,6 @@
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -2274,6 +2284,15 @@
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.2.0"
+      }
+    },
+    "node_modules/@types/react-window": {
+      "version": "1.8.8",
+      "resolved": "https://registry.npmjs.org/@types/react-window/-/react-window-1.8.8.tgz",
+      "integrity": "sha512-8Ls660bHR1AUA2kuRvVG9D/4XpRC6wjAaPT9dil7Ckc76eP9TKWZwwmgfq8Q1LANX3QNDnoU4Zp48A3w+zK69Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/react": "*"
       }
     },
     "node_modules/@types/responselike": {
@@ -3851,7 +3870,6 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/dayjs": {
@@ -6161,6 +6179,12 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/memoize-one": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.1.tgz",
+      "integrity": "sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==",
+      "license": "MIT"
+    },
     "node_modules/merge2": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -7285,6 +7309,23 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-window": {
+      "version": "1.8.11",
+      "resolved": "https://registry.npmjs.org/react-window/-/react-window-1.8.11.tgz",
+      "integrity": "sha512-+SRbUVT2scadgFSWx+R1P754xHPEqvcfSfVX10QYg6POOz+WNgkN48pS+BtZNIMGiL1HYrSEiCkwsMS15QogEQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.0.0",
+        "memoize-one": ">=3.1.1 <6"
+      },
+      "engines": {
+        "node": ">8.0.0"
+      },
+      "peerDependencies": {
+        "react": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/read-binary-file-arch": {

--- a/electron/package.json
+++ b/electron/package.json
@@ -18,11 +18,13 @@
   },
   "dependencies": {
     "@tanstack/react-table": "^8.20.0",
+    "@types/react-window": "^1.8.8",
     "electron-store": "^8.2.0",
     "exceljs": "^4.4.0",
     "papaparse": "^5.4.1",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
+    "react-window": "^1.8.11",
     "zustand": "^5.0.0"
   },
   "devDependencies": {

--- a/electron/src/renderer/components/matrix/CrosspointMatrix.tsx
+++ b/electron/src/renderer/components/matrix/CrosspointMatrix.tsx
@@ -1,4 +1,5 @@
-import React, { useEffect, useState, useCallback, useMemo, useRef } from 'react'
+import React, { useEffect, useState, useCallback, useMemo, useRef, useLayoutEffect } from 'react'
+import { FixedSizeGrid, GridChildComponentProps, GridOnScrollProps } from 'react-window'
 import { useRouterStore } from '../../stores/router-store'
 import { useLabelsStore } from '../../stores/labels-store'
 import { useUIStore } from '../../stores/ui-store'
@@ -154,6 +155,51 @@ const MatrixCell = React.memo(function MatrixCell({
 })
 
 // ---------------------------------------------------------------------------
+// Virtualized cell renderer (react-window)
+// ---------------------------------------------------------------------------
+
+interface CellData {
+  routeMap: Map<number, number>
+  flashMap: Record<string, string>
+  hoveredRow: number | null
+  hoveredCol: number | null
+  cellSize: number
+  inputLabels: Array<{ currentLabel: string }>
+  outputLabels: Array<{ currentLabel: string }>
+  getRouteColor: (outputIdx: number) => string
+  handleRoute: (o: number, i: number) => void
+  handleClear: (o: number) => void
+  handleCellHover: (o: number, i: number) => void
+}
+
+function VirtualCell({ columnIndex, rowIndex, style, data }: GridChildComponentProps<CellData>) {
+  const d = data
+  const o = rowIndex
+  const i = columnIndex
+  const cellKey = `${o}-${i}`
+  const isRouted = d.routeMap.get(o) === i
+  return (
+    <div style={style}>
+      <MatrixCell
+        outputIdx={o}
+        inputIdx={i}
+        isRouted={isRouted}
+        color={d.getRouteColor(o)}
+        cellSize={d.cellSize}
+        isHoveredRow={d.hoveredRow === o}
+        isHoveredCol={d.hoveredCol === i}
+        flashKey={d.flashMap[cellKey] || null}
+        onRoute={d.handleRoute}
+        onClear={d.handleClear}
+        onHover={d.handleCellHover}
+        inputLabel={d.inputLabels[i]?.currentLabel || `Input ${i + 1}`}
+        outputLabel={d.outputLabels[o]?.currentLabel || `Output ${o + 1}`}
+      />
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
 // Skeleton loader
 // ---------------------------------------------------------------------------
 
@@ -200,6 +246,13 @@ export default function CrosspointMatrix() {
   const [statusMsg, setStatusMsg] = useState<string>('')
   const [flashMap, setFlashMap] = useState<Record<string, string>>({})
   const scrollRef = useRef<HTMLDivElement>(null)
+
+  // Virtualization: measure the scrollable body to size the FixedSizeGrid
+  const bodyRef = useRef<HTMLDivElement>(null)
+  const [bodySize, setBodySize] = useState({ width: 800, height: 500 })
+  // Scroll sync: translate header strips instead of re-rendering
+  const inputHeaderInnerRef = useRef<HTMLDivElement>(null)
+  const outputHeaderInnerRef = useRef<HTMLDivElement>(null)
 
   const inputCount = router.inputCount
   const outputCount = router.outputCount
@@ -330,6 +383,46 @@ export default function CrosspointMatrix() {
   const LABEL_COL_W = 160
   const LABEL_ROW_H = 140
 
+  // ---- virtualization: measure + scroll sync ------------------------------
+
+  useLayoutEffect(() => {
+    if (!bodyRef.current) return
+    const el = bodyRef.current
+    const update = () => {
+      setBodySize({ width: el.clientWidth, height: el.clientHeight })
+    }
+    update()
+    const ro = new ResizeObserver(update)
+    ro.observe(el)
+    return () => ro.disconnect()
+  }, [loading])
+
+  const onGridScroll = useCallback(({ scrollLeft, scrollTop }: GridOnScrollProps) => {
+    if (inputHeaderInnerRef.current) {
+      inputHeaderInnerRef.current.style.transform = `translate3d(${-scrollLeft}px, 0, 0)`
+    }
+    if (outputHeaderInnerRef.current) {
+      outputHeaderInnerRef.current.style.transform = `translate3d(0, ${-scrollTop}px, 0)`
+    }
+  }, [])
+
+  const cellData = useMemo<CellData>(() => ({
+    routeMap,
+    flashMap,
+    hoveredRow,
+    hoveredCol,
+    cellSize,
+    inputLabels,
+    outputLabels,
+    getRouteColor,
+    handleRoute,
+    handleClear,
+    handleCellHover,
+  }), [routeMap, flashMap, hoveredRow, hoveredCol, cellSize, inputLabels, outputLabels, getRouteColor, handleRoute, handleClear, handleCellHover])
+
+  const gridWidth = Math.max(0, bodySize.width - LABEL_COL_W)
+  const gridHeight = Math.max(0, bodySize.height - LABEL_ROW_H)
+
   // ---- render -------------------------------------------------------------
 
   return (
@@ -367,9 +460,10 @@ export default function CrosspointMatrix() {
           style={{
             display: 'flex',
             flexDirection: 'column',
-            maxWidth: '95vw',
-            maxHeight: '95vh',
-            width: 'fit-content',
+            // Grow to hold the matrix at its natural size, capped at viewport.
+            // Extra width: label col + (cells) + scrollbar; height: toolbar + label row + (cells) + statusbar + scrollbar.
+            width: `min(${LABEL_COL_W + inputCount * cellSize + 20}px, 95vw)`,
+            height: `min(${LABEL_ROW_H + outputCount * cellSize + 100}px, 95vh)`,
             background: C.surface,
             borderRadius: 12,
             border: `1px solid ${C.border}`,
@@ -512,144 +606,173 @@ export default function CrosspointMatrix() {
             </div>
           </div>
 
-          {/* ---- MATRIX BODY ---- */}
+          {/* ---- MATRIX BODY (virtualized) ---- */}
           {loading ? (
             <SkeletonGrid />
           ) : (
             <div
-              ref={scrollRef}
+              ref={bodyRef}
               onMouseLeave={handleMouseLeave}
               style={{
-                overflow: 'auto',
                 flex: 1,
                 minHeight: 0,
+                display: 'grid',
+                gridTemplateColumns: `${LABEL_COL_W}px 1fr`,
+                gridTemplateRows: `${LABEL_ROW_H}px 1fr`,
+                overflow: 'hidden',
                 position: 'relative',
               }}
             >
-              {/* CSS Grid matrix wrapper */}
+              {/* ---- TOP-LEFT CORNER ---- */}
               <div
                 style={{
-                  display: 'grid',
-                  gridTemplateColumns: `${LABEL_COL_W}px repeat(${inputCount}, ${cellSize}px)`,
-                  gridTemplateRows: `${LABEL_ROW_H}px repeat(${outputCount}, ${cellSize}px)`,
-                  width: 'fit-content',
-                  minWidth: '100%',
+                  gridColumn: 1,
+                  gridRow: 1,
+                  background: C.surface,
+                  borderRight: `1px solid ${C.border}`,
+                  borderBottom: `2px solid ${C.border}`,
+                  display: 'flex',
+                  alignItems: 'flex-end',
+                  justifyContent: 'flex-end',
+                  padding: '4px 8px',
+                  zIndex: 30,
                 }}
               >
-                {/* ---- TOP-LEFT CORNER (empty) ---- */}
+                <span style={{ color: C.textDim, fontSize: 9, fontWeight: 600, letterSpacing: 0.5, textTransform: 'uppercase' }}>
+                  OUT / IN
+                </span>
+              </div>
+
+              {/* ---- INPUT LABELS STRIP (top, scrolls with grid horizontally) ---- */}
+              <div
+                style={{
+                  gridColumn: 2,
+                  gridRow: 1,
+                  overflow: 'hidden',
+                  background: C.surface,
+                  borderBottom: `2px solid ${C.border}`,
+                  position: 'relative',
+                }}
+              >
                 <div
+                  ref={inputHeaderInnerRef}
                   style={{
-                    position: 'sticky',
-                    top: 0,
-                    left: 0,
-                    zIndex: 30,
-                    background: C.surface,
-                    borderRight: `1px solid ${C.border}`,
-                    borderBottom: `2px solid ${C.border}`,
                     display: 'flex',
-                    alignItems: 'flex-end',
-                    justifyContent: 'flex-end',
-                    padding: '4px 8px',
+                    width: inputCount * cellSize,
+                    height: LABEL_ROW_H,
+                    willChange: 'transform',
                   }}
                 >
-                  <span style={{ color: C.textDim, fontSize: 9, fontWeight: 600, letterSpacing: 0.5, textTransform: 'uppercase' }}>
-                    OUT / IN
-                  </span>
-                </div>
-
-                {/* ---- INPUT LABELS (top header row) ---- */}
-                {Array.from({ length: inputCount }).map((_, i) => {
-                  const label = inputLabels[i]?.currentLabel || `In ${i + 1}`
-                  const highlighted = hoveredCol === i
-                  return (
-                    <div
-                      key={`ih-${i}`}
-                      style={{
-                        position: 'sticky',
-                        top: 0,
-                        zIndex: 20,
-                        background: highlighted
-                          ? `linear-gradient(180deg, ${C.surface} 0%, rgba(123,47,190,0.1) 100%)`
-                          : C.surface,
-                        borderRight: `1px solid ${C.border}`,
-                        borderBottom: `2px solid ${highlighted ? C.accent : C.border}`,
-                        display: 'flex',
-                        flexDirection: 'column',
-                        alignItems: 'center',
-                        justifyContent: 'flex-start',
-                        padding: '6px 0 6px 0',
-                        overflow: 'hidden',
-                        transition: 'background 150ms, border-color 150ms',
-                      }}
-                      title={label}
-                    >
-                      {/* Port number */}
-                      <span
-                        style={{
-                          fontSize: 15,
-                          fontWeight: 800,
-                          color: highlighted ? C.text : C.accent,
-                          fontFamily: 'Consolas, "Courier New", monospace',
-                          lineHeight: 1,
-                          marginBottom: 3,
-                          flexShrink: 0,
-                        }}
-                      >
-                        {i + 1}
-                      </span>
-                      {/* Label name - vertical, reading top to bottom */}
+                  {Array.from({ length: inputCount }).map((_, i) => {
+                    const label = inputLabels[i]?.currentLabel || `In ${i + 1}`
+                    const highlighted = hoveredCol === i
+                    return (
                       <div
+                        key={`ih-${i}`}
                         style={{
-                          writingMode: 'vertical-lr',
-                          whiteSpace: 'nowrap',
+                          width: cellSize,
+                          minWidth: cellSize,
+                          height: LABEL_ROW_H,
+                          background: highlighted
+                            ? `linear-gradient(180deg, ${C.surface} 0%, rgba(123,47,190,0.1) 100%)`
+                            : C.surface,
+                          borderRight: `1px solid ${C.border}`,
+                          borderBottom: highlighted ? `2px solid ${C.accent}` : 'none',
+                          display: 'flex',
+                          flexDirection: 'column',
+                          alignItems: 'center',
+                          justifyContent: 'flex-start',
+                          padding: '6px 0',
                           overflow: 'hidden',
-                          textOverflow: 'ellipsis',
-                          maxHeight: LABEL_ROW_H - 26,
-                          fontSize: 16,
-                          fontFamily: 'Consolas, "Courier New", monospace',
-                          fontWeight: highlighted ? 700 : 500,
-                          color: highlighted ? C.text : C.textMuted,
-                          transition: 'color 150ms',
-                          lineHeight: 1.1,
+                          transition: 'background 150ms, border-color 150ms',
+                          boxSizing: 'border-box',
                         }}
+                        title={label}
                       >
-                        {label}
+                        <span
+                          style={{
+                            fontSize: 15,
+                            fontWeight: 800,
+                            color: highlighted ? C.text : C.accent,
+                            fontFamily: 'Consolas, "Courier New", monospace',
+                            lineHeight: 1,
+                            marginBottom: 3,
+                            flexShrink: 0,
+                          }}
+                        >
+                          {i + 1}
+                        </span>
+                        <div
+                          style={{
+                            writingMode: 'vertical-lr',
+                            whiteSpace: 'nowrap',
+                            overflow: 'hidden',
+                            textOverflow: 'ellipsis',
+                            maxHeight: LABEL_ROW_H - 26,
+                            fontSize: 16,
+                            fontFamily: 'Consolas, "Courier New", monospace',
+                            fontWeight: highlighted ? 700 : 500,
+                            color: highlighted ? C.text : C.textMuted,
+                            transition: 'color 150ms',
+                            lineHeight: 1.1,
+                          }}
+                        >
+                          {label}
+                        </div>
                       </div>
-                    </div>
-                  )
-                })}
+                    )
+                  })}
+                </div>
+              </div>
 
-                {/* ---- OUTPUT ROWS ---- */}
-                {Array.from({ length: outputCount }).map((_, o) => {
-                  const outLabel = outputLabels[o]?.currentLabel || `Out ${o + 1}`
-                  const rowHighlighted = hoveredRow === o
-                  const routeColor = getRouteColor(o)
-
-                  return (
-                    <React.Fragment key={`row-${o}`}>
-                      {/* Output label (sticky left) */}
+              {/* ---- OUTPUT LABELS STRIP (left, scrolls with grid vertically) ---- */}
+              <div
+                style={{
+                  gridColumn: 1,
+                  gridRow: 2,
+                  overflow: 'hidden',
+                  background: C.surface,
+                  borderRight: `1px solid ${C.border}`,
+                  position: 'relative',
+                }}
+              >
+                <div
+                  ref={outputHeaderInnerRef}
+                  style={{
+                    display: 'flex',
+                    flexDirection: 'column',
+                    width: LABEL_COL_W,
+                    height: outputCount * cellSize,
+                    willChange: 'transform',
+                  }}
+                >
+                  {Array.from({ length: outputCount }).map((_, o) => {
+                    const outLabel = outputLabels[o]?.currentLabel || `Out ${o + 1}`
+                    const rowHighlighted = hoveredRow === o
+                    const routeColor = getRouteColor(o)
+                    return (
                       <div
+                        key={`oh-${o}`}
                         style={{
-                          position: 'sticky',
-                          left: 0,
-                          zIndex: 10,
+                          width: LABEL_COL_W,
+                          height: cellSize,
+                          minHeight: cellSize,
                           background: rowHighlighted
                             ? `linear-gradient(90deg, ${C.surface} 0%, rgba(123,47,190,0.1) 100%)`
                             : C.surface,
-                          borderRight: `2px solid ${rowHighlighted ? C.accent : C.border}`,
+                          borderRight: rowHighlighted ? `2px solid ${C.accent}` : 'none',
                           borderBottom: `1px solid ${C.border}`,
                           display: 'flex',
                           alignItems: 'center',
                           justifyContent: 'flex-end',
                           paddingRight: 10,
                           paddingLeft: 6,
-                          height: cellSize,
                           overflow: 'hidden',
                           transition: 'background 150ms, border-color 150ms',
+                          boxSizing: 'border-box',
                         }}
                         title={outLabel}
                       >
-                        {/* Color dot for KUMO */}
                         {isKumo && (
                           <div style={{
                             width: 6,
@@ -660,7 +783,6 @@ export default function CrosspointMatrix() {
                             flexShrink: 0,
                           }} />
                         )}
-                        {/* Port number */}
                         <span
                           style={{
                             fontSize: 15,
@@ -692,33 +814,29 @@ export default function CrosspointMatrix() {
                           {outLabel}
                         </span>
                       </div>
+                    )
+                  })}
+                </div>
+              </div>
 
-                      {/* Cells for this row */}
-                      {Array.from({ length: inputCount }).map((_, i) => {
-                        const isRouted = routeMap.get(o) === i
-                        const cellKey = `${o}-${i}`
-                        return (
-                          <MatrixCell
-                            key={cellKey}
-                            outputIdx={o}
-                            inputIdx={i}
-                            isRouted={isRouted}
-                            color={routeColor}
-                            cellSize={cellSize}
-                            isHoveredRow={hoveredRow === o}
-                            isHoveredCol={hoveredCol === i}
-                            flashKey={flashMap[cellKey] || null}
-                            onRoute={handleRoute}
-                            onClear={handleClear}
-                            onHover={handleCellHover}
-                            inputLabel={inputLabels[i]?.currentLabel || `Input ${i + 1}`}
-                            outputLabel={outLabel}
-                          />
-                        )
-                      })}
-                    </React.Fragment>
-                  )
-                })}
+              {/* ---- VIRTUALIZED GRID (bottom-right cell) ---- */}
+              <div ref={scrollRef} style={{ gridColumn: 2, gridRow: 2, overflow: 'hidden' }}>
+                {gridWidth > 0 && gridHeight > 0 && (
+                  <FixedSizeGrid
+                    columnCount={inputCount}
+                    rowCount={outputCount}
+                    columnWidth={cellSize}
+                    rowHeight={cellSize}
+                    width={gridWidth}
+                    height={gridHeight}
+                    itemData={cellData}
+                    onScroll={onGridScroll}
+                    overscanColumnCount={4}
+                    overscanRowCount={4}
+                  >
+                    {VirtualCell}
+                  </FixedSizeGrid>
+                )}
               </div>
             </div>
           )}


### PR DESCRIPTION
## Summary
At 64×64 the crosspoint matrix was rendering ~4,100 cell DOM nodes unconditionally — expensive to mount and re-render on every hover state change (per the audit's perf finding #2). This PR replaces the inner NxN CSS grid with a `react-window` `FixedSizeGrid` while keeping the visual layout and behavior identical.

- DOM impact at 64×64: **~4,100 → ~450 live cell nodes** (visible + overscan 4)
- Bundle impact: **+~33 KB** renderer (react-window 1.8.x)
- No behavioral changes: routing, clearing, hover crosshair, KUMO color dots, flash animations, skeleton loader all preserved
- No new deps in main/preload

## How it works
The matrix body is now a 2×2 CSS grid:

```
[ corner (fixed) ][ input header strip (overflow:hidden) ]
[ output header strip ][ FixedSizeGrid                   ]
[ (overflow:hidden)   ][ (own scrollbars)                ]
```

- Only the inner NxN cell region is virtualized (O(N²)).
- Header strips (input labels on top, output labels on left) stay normal DOM — they're only O(N), not O(N²), so virtualizing them adds no value.
- Header strips are rendered inside `overflow:hidden` viewports and their inner content is `translate3d`-moved on the grid's `onScroll` callback. **No React re-renders during scroll** — the transform mutation hits refs directly.
- `cellData` (route map, hover, labels, handlers) is passed as `itemData` and memoized; `MatrixCell` remains `React.memo`-wrapped so unchanged cells still bail.

The outer panel size now uses `min(${natural}px, 95vw/95vh)` since `width: fit-content` no longer applies (virtualized body has its own scrollbars).

## Test plan
- [x] `npm run typecheck` passes
- [x] `npm run build` passes
- [ ] Manual: open Crosspoint Matrix on a KUMO 64×64 — scroll both axes and confirm headers track the cell grid exactly
- [ ] Manual: hover crosshair highlight still appears on both the row and column header (not just the cells)
- [ ] Manual: click to route / right-click to clear still works; flash animation fires
- [ ] Manual: on a 16×16 or 32×32 router the matrix still fits without unnecessary scrollbars
- [ ] Manual: close/reopen dialog several times — no stale scroll offsets on headers

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Virtualize the crosspoint matrix grid using react-window to reduce DOM nodes and improve rendering performance while preserving existing behavior and layout.

New Features:
- Introduce a virtualized FixedSizeGrid-backed matrix body for rendering crosspoint cells.

Enhancements:
- Adjust the matrix dialog sizing to compute width and height based on label and cell dimensions instead of using fit-content.
- Refactor matrix body layout into a 2×2 CSS grid separating corner, header strips, and the virtualized cell region, with scroll-synced headers via transforms.

Build:
- Add react-window and its TypeScript types as renderer dependencies.