### PR TITLE
docs: sync README/VERSION/FIXES_SUMMARY to v5.1.0

### DIFF
--- a/FIXES_SUMMARY.md
+++ b/FIXES_SUMMARY.md
@@ -290,6 +290,19 @@ For issues or questions:
 
 ---
 
-**Last Updated**: 2026-02-15
-**Version**: 5.0.0
+**Last Updated**: 2026-04-15
+**Version**: 5.1.0
 **Status**: ✅ All critical issues resolved
+
+---
+
+## v5.1.0 Fixes (March 24, 2026)
+
+- **ComboBox dark theme** - All dropdown menus now render with correct dark theme colors (previously defaulted to white background)
+- **Auto-Discover port detection** - Independent input/output count detection fixes wrong port counts on asymmetric KUMO models (3216, 6432)
+- **Lightware label download** - Reliability improvements to LW3 label fetching
+- **Clipboard paste** - Fixed paste-from-clipboard into the label grid
+- **Matrix layout** - Crosspoint matrix layout fixes
+- **Letter Mode** - Auto-Number now supports letter sequences (A-Z, AA, AB...)
+- **Single-click cell editing** - Click directly on New Label or Color cells to edit inline
+- **AJA KUMO colors** - Color column with visual swatches, bulk color assignment via context menu

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Helix v5.0
+# Helix v5.1
 
 **Professional AV Production Tool for Live Events**
 
@@ -26,6 +26,15 @@ Complete solution for managing video router labels across AJA KUMO, Videohub, an
 
 **Lightware MX2**
 - All MX2 models with LW3 protocol support (TCP 6107)
+
+### What's New in v5.1
+
+- **Electron desktop app** - First packaged cross-platform build (v1.1.0)
+- **AJA KUMO label colors** - Color column with visual swatches, bulk color assignment via context menu
+- **Single-click cell editing** - Click directly on New Label or Color cells to edit inline
+- **Auto-Number Letter Mode** - Letter sequences (A-Z, AA, AB...) with configurable starting letter
+- **Auto-Discover port detection** - Independent input/output count detection for asymmetric KUMO models (3216, 6432)
+- **ComboBox dark theme fix** - Dropdown menus now render correctly in dark theme
 
 ### What's New in v5.0
 
@@ -144,7 +153,7 @@ Works with CSV (recommended) or Excel (.xlsx). Columns:
 | New_Label | Your desired label (leave blank to skip) |
 | Notes | Optional documentation |
 
-Labels must be 50 characters or fewer for AJA KUMO. The app warns you if any labels exceed this limit.
+Label length limits vary by router — the app enforces the correct per-router limit (up to 255 chars) and warns if any label exceeds it. AJA KUMO hardware typically displays the first ~16 characters on its front panel regardless.
 
 ## Batch Operations
 
@@ -216,7 +225,15 @@ Set-ExecutionPolicy RemoteSigned -Scope CurrentUser
 
 ## Version History
 
-### v5.0 (Current)
+### v5.1 (Current)
+- First packaged Electron desktop app release (v1.1.0)
+- AJA KUMO label colors with bulk assignment
+- Single-click cell editing for New Label and Color columns
+- Auto-Number Letter Mode (A-Z, AA, AB...)
+- Auto-Discover independent input/output port detection (3216, 6432)
+- Dark-theme ComboBox rendering fix
+
+### v5.0
 - Multi-router support: AJA KUMO, Blackmagic Videohub, and Lightware MX2
 - Crosspoint matrix view for routing connections
 - Security hardening (HTTPS-first with HTTP fallback, input validation)

--- a/VERSION.md
+++ b/VERSION.md
@@ -89,8 +89,11 @@
 ## Technical Specifications
 
 ### Supported KUMO Models
+- **KUMO 1604** - 16x4 SDI router
 - **KUMO 1616** - 16x16 SDI router
 - **KUMO 3232** - 32x32 SDI router
+- **KUMO 3216** - 32x16 asymmetric SDI router
+- **KUMO 6432** - 64x32 asymmetric SDI router
 - **KUMO 6464** - 64x64 SDI router (via KUMO CP2)
 - **KUMO 1616-12G** - 12G-SDI support
 - **KUMO 3232-12G** - 12G-SDI support


### PR DESCRIPTION
## Summary
Bring docs in line with the v5.1.0 release that's already reflected in `VERSION.md`. Pure documentation — no code changes.

- **README.md**
  - Title bumped from "Helix v5.0" to "Helix v5.1"
  - Add "What's New in v5.1" section above the v5.0 section
  - Update Version History to show v5.1 as Current
  - Clarify label length limit (up to 255 chars, varies by router) — the old copy said 50 which didn't match the code
- **VERSION.md** — add KUMO 1604 (16x4), 3216 / 6432 (asymmetric) to Supported Models
- **FIXES_SUMMARY.md** — footer bumped to 5.1.0 / 2026-04-15, new "v5.1.0 Fixes" section listing the fixes from the recent commit history

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Update documentation to reflect the Helix v5.1.0 release features and fixes.

New Features:
- Document new v5.1 desktop Electron app release and key feature additions such as label colors, single-click editing, Auto-Number Letter Mode, and improved Auto-Discover behavior.

Enhancements:
- Clarify router-specific label length limits and front panel display behavior in the README.
- Expand supported AJA KUMO model list in VERSION.md to include 1604 and asymmetric 3216 / 6432 variants.
- Add v5.1.0 fixes section and refresh metadata in FIXES_SUMMARY.md to capture recent bug fixes and improvements.

Documentation:
- Revise README versioning, What's New sections, and Version History to make v5.1 the current release and document its major changes.