### PR TITLE
refactor(protocols): dedupe probePort, drop LW3 debug logs, worker-pool subnet scan

### DIFF
--- a/electron/src/main/protocols/auto-detect.ts
+++ b/electron/src/main/protocols/auto-detect.ts
@@ -3,42 +3,17 @@
 // 2. Videohub (TCP 9990)
 // 3. KUMO (HTTP 80)
 
-import * as net from 'net'
 import { RouterType } from './types'
 import { kumoTestConnection } from './kumo-rest'
+import { probePort } from './net-utils'
 
 const PROBE_TIMEOUT = 2500
-
-function probePort(ip: string, port: number, timeout = PROBE_TIMEOUT): Promise<boolean> {
-  return new Promise((resolve) => {
-    const sock = new net.Socket()
-    const timer = setTimeout(() => {
-      sock.destroy()
-      resolve(false)
-    }, timeout)
-
-    sock.connect(port, ip, () => {
-      clearTimeout(timer)
-      sock.destroy()
-      resolve(true)
-    })
-
-    sock.on('error', () => {
-      clearTimeout(timer)
-      resolve(false)
-    })
-  })
-}
+const LIGHTWARE_PORT = 6107
+const VIDEOHUB_PORT = 9990
 
 export async function detectRouterType(ip: string): Promise<RouterType | null> {
-  // Probe Lightware (6107)
-  if (await probePort(ip, 6107)) return 'lightware'
-
-  // Probe Videohub (9990)
-  if (await probePort(ip, 9990)) return 'videohub'
-
-  // Probe KUMO (HTTP 80 REST API)
+  if (await probePort(ip, LIGHTWARE_PORT, PROBE_TIMEOUT)) return 'lightware'
+  if (await probePort(ip, VIDEOHUB_PORT, PROBE_TIMEOUT)) return 'videohub'
   if (await kumoTestConnection(ip)) return 'kumo'
-
   return null
 }

--- a/electron/src/main/protocols/lightware.ts
+++ b/electron/src/main/protocols/lightware.ts
@@ -133,7 +133,6 @@ export async function lightwareConnect(ip: string): Promise<ConnectResult> {
     // Product name
     let productName = 'Lightware MX2'
     const pnLines = await lw3SendCommand(sock, 'GET /.ProductName', sendId)
-    console.log('[LW3] ProductName response lines:', pnLines.length, pnLines)
     for (const line of pnLines) {
       const val = extractValue(line)
       if (val) { productName = val; break }
@@ -141,7 +140,6 @@ export async function lightwareConnect(ip: string): Promise<ConnectResult> {
 
     // Get labels to derive port counts (SourcePortCount/DestinationPortCount don't exist on MX2)
     const labelLines = await lw3SendCommand(sock, 'GET /MEDIA/NAMES/VIDEO.*', sendId)
-    console.log('[LW3] Label response lines:', labelLines.length)
     let inputCount = 0
     let outputCount = 0
 
@@ -162,7 +160,6 @@ export async function lightwareConnect(ip: string): Promise<ConnectResult> {
       }
     }
 
-    console.log(`[LW3] Connect result: ${productName}, inputs=${inputCount}, outputs=${outputCount}`)
     return {
       success: true,
       routerType: 'lightware',
@@ -194,7 +191,6 @@ export async function lightwareDownloadLabels(ip: string): Promise<Label[]> {
   try {
     // Get all labels — response: "pw /MEDIA/NAMES/VIDEO.I1=1;Input 1"
     const labelLines = await lw3SendCommand(sock, 'GET /MEDIA/NAMES/VIDEO.*', sendId)
-    console.log('[LW3] Download label lines:', labelLines.length, labelLines.slice(0, 4))
     const inputLabels = new Map<number, string>()
     const outputLabels = new Map<number, string>()
     // Match with page;name format OR plain name (fallback)

--- a/electron/src/main/protocols/net-utils.ts
+++ b/electron/src/main/protocols/net-utils.ts
@@ -1,0 +1,29 @@
+// Shared net helpers used by auto-detect and network-scanner.
+
+import * as net from 'net'
+
+/**
+ * TCP connect probe with timeout. Returns true if the port accepts a connection.
+ * Resolves (never rejects) so callers can treat it as a simple boolean.
+ */
+export function probePort(ip: string, port: number, timeout: number): Promise<boolean> {
+  return new Promise((resolve) => {
+    const sock = new net.Socket()
+    const timer = setTimeout(() => {
+      sock.destroy()
+      resolve(false)
+    }, timeout)
+
+    sock.connect(port, ip, () => {
+      clearTimeout(timer)
+      sock.destroy()
+      resolve(true)
+    })
+
+    sock.on('error', () => {
+      clearTimeout(timer)
+      sock.destroy()
+      resolve(false)
+    })
+  })
+}

--- a/electron/src/main/protocols/network-scanner.ts
+++ b/electron/src/main/protocols/network-scanner.ts
@@ -1,12 +1,14 @@
 // IP range scanner — probes a /24 subnet for routers
-// Checks ports 6107 (Lightware), 9990 (Videohub), 80 (KUMO) in parallel batches
+// Checks ports 6107 (Lightware), 9990 (Videohub), 80 (KUMO) in parallel.
 
-import * as net from 'net'
 import { RouterType } from './types'
 import { kumoTestConnection } from './kumo-rest'
+import { probePort } from './net-utils'
 
 const SCAN_PROBE_TIMEOUT = 500
-const BATCH_SIZE = 25
+const LIGHTWARE_PORT = 6107
+const VIDEOHUB_PORT = 9990
+const KUMO_HTTP_PORT = 80
 
 export interface DiscoveredRouter {
   ip: string
@@ -20,34 +22,12 @@ export interface ScanProgress {
   found: DiscoveredRouter[]
 }
 
-function probePort(ip: string, port: number, timeout = SCAN_PROBE_TIMEOUT): Promise<boolean> {
-  return new Promise((resolve) => {
-    const sock = new net.Socket()
-    const timer = setTimeout(() => {
-      sock.destroy()
-      resolve(false)
-    }, timeout)
-
-    sock.connect(port, ip, () => {
-      clearTimeout(timer)
-      sock.destroy()
-      resolve(true)
-    })
-
-    sock.on('error', () => {
-      clearTimeout(timer)
-      sock.destroy()
-      resolve(false)
-    })
-  })
-}
-
 async function detectAtIp(ip: string): Promise<{ routerType: RouterType; deviceName: string } | null> {
   // Probe all three ports in parallel for speed
   const [lightware, videohub, kumo] = await Promise.all([
-    probePort(ip, 6107),
-    probePort(ip, 9990),
-    probePort(ip, 80).then(async (open) => {
+    probePort(ip, LIGHTWARE_PORT, SCAN_PROBE_TIMEOUT),
+    probePort(ip, VIDEOHUB_PORT, SCAN_PROBE_TIMEOUT),
+    probePort(ip, KUMO_HTTP_PORT, SCAN_PROBE_TIMEOUT).then(async (open) => {
       if (!open) return false
       // Port 80 is common — confirm it's actually a KUMO
       try {
@@ -71,6 +51,8 @@ async function detectAtIp(ip: string): Promise<{ routerType: RouterType; deviceN
  * @param onProgress - Called after each batch with current progress
  * @returns Array of all discovered routers
  */
+const MAX_CONCURRENT_PROBES = 50
+
 export async function scanSubnet(
   baseIp: string,
   onProgress?: (progress: ScanProgress) => void,
@@ -81,31 +63,26 @@ export async function scanSubnet(
   const found: DiscoveredRouter[] = []
   const total = 254
   let scanned = 0
+  let nextHost = 1
 
-  // Process in batches to avoid flooding the network
-  for (let batchStart = 1; batchStart <= 254; batchStart += BATCH_SIZE) {
-    const batchEnd = Math.min(batchStart + BATCH_SIZE - 1, 254)
-    const batchPromises: Promise<void>[] = []
-
-    for (let i = batchStart; i <= batchEnd; i++) {
-      const ip = `${base}.${i}`
-      batchPromises.push(
-        detectAtIp(ip).then((result) => {
-          if (result) {
-            const router: DiscoveredRouter = { ip, ...result }
-            found.push(router)
-          }
-        }),
-      )
-    }
-
-    await Promise.all(batchPromises)
-    scanned = Math.min(batchEnd, 254)
-
-    if (onProgress) {
-      onProgress({ scanned, total, found: [...found] })
+  // Worker-pool pattern: N workers pull from a shared counter.
+  // Reports progress after every probe completes rather than every batch.
+  async function worker(): Promise<void> {
+    while (nextHost <= total) {
+      const host = nextHost++
+      const ip = `${base}.${host}`
+      const result = await detectAtIp(ip)
+      if (result) {
+        found.push({ ip, ...result })
+      }
+      scanned++
+      if (onProgress) {
+        onProgress({ scanned, total, found: [...found] })
+      }
     }
   }
 
+  const workerCount = Math.min(MAX_CONCURRENT_PROBES, total)
+  await Promise.all(Array.from({ length: workerCount }, () => worker()))
   return found
 }


### PR DESCRIPTION
## Summary
Small-scope audit cleanups for the Electron main process protocol layer. No behavioral changes except the subnet scanner is faster and reports finer-grained progress.

### Dedupe
- `probePort` was an 18-line identical helper in both `auto-detect.ts` and `network-scanner.ts`. Extract to `protocols/net-utils.ts` and import from both.
- Magic port literals `6107` / `9990` / `80` replaced with named constants (`LIGHTWARE_PORT`, `VIDEOHUB_PORT`, `KUMO_HTTP_PORT`) at the call sites.

### Logging
- Drop four leftover `console.log('[LW3] ...')` debug statements in `lightware.ts` (ProductName + label response dumps, connect result, download preview). These were printed to DevTools on every connect/download with no debug flag gating them.

### Perf
- `scanSubnet` previously ran 11 sequential batches of 25 probes (`BATCH_SIZE=25`, 254/25 rounds). Replace with a **worker-pool of 50 concurrent probes** pulling from a shared counter — roughly halves scan wall-time on a quiet /24.
- Now emits progress after every probe instead of only at batch boundaries, so the UI progress bar advances smoothly.

## Test plan
- [x] `npm run typecheck` passes
- [x] `npm run build` passes
- [ ] Manual: run subnet scan on `192.168.100` — confirm it finds all known devices and progress bar advances smoothly
- [ ] Manual: connect to Lightware MX2 at 192.168.100.51 — DevTools console shows no `[LW3]` spam

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Refactor protocol networking utilities and improve subnet scanning behavior.

Enhancements:
- Deduplicate TCP port probing logic into a shared net-utils helper used by auto-detect and network-scanner.
- Replace magic router port literals with named constants for Lightware, Videohub, and KUMO HTTP endpoints.
- Rework subnet scanning to use a bounded worker pool with finer-grained progress reporting for smoother UI feedback.
- Remove leftover Lightware protocol debug console logging to reduce unnecessary DevTools output.